### PR TITLE
Fix issue #6

### DIFF
--- a/src/IntExpr.jl
+++ b/src/IntExpr.jl
@@ -463,6 +463,8 @@ Base.inv(e::NumericInteroperableExpr) = 1.0 / e # this performs the correct prom
 Performs manual conversion of an IntExpr to a RealExpr. Note that Satisfiability.jl automatically promotes types in arithmetic and comparison expressions, so this function is usually unnecessary to explicitly call.
 """
 to_real(a::IntExpr) = RealExpr(:to_real, [a], isnothing(a.value) ? nothing : Float64(a.value), __get_hash_name(:to_real, [a]))
+to_real(a::RealExpr) = a # if we don't define this someone will call it and get a crash
+to_real(a::Union{Number, Nothing}) = isnothing(a) ? nothing : Float64(a) # this is needed for __propagate_value! to correctly propagate values
 
 """
     to_int(a::RealExpr)
@@ -470,6 +472,8 @@ to_real(a::IntExpr) = RealExpr(:to_real, [a], isnothing(a.value) ? nothing : Flo
 Performs manual conversion of a RealExpr to an IntExpr. Equivalent to Julia `Int(floor(a))`.
 """
 to_int(a::RealExpr) = IntExpr(:to_int, [a], isnothing(a.value) ? nothing : Int(floor(a.value)), __get_hash_name(:to_int, [a]))
+to_int(a::IntExpr) = a
+to_int(a::Union{Number, Nothing}) = isnothing(a) ? nothing : Int(floor(a)) # this is needed for __propagate_value! to correctly propagate values
 
 ##### PROMOTION RULES #####
 # These govern the promotion of BoolExpr, IntExpr and RealExpr types.

--- a/test/int_real_tests.jl
+++ b/test/int_real_tests.jl
@@ -94,3 +94,18 @@ end
     @test isequal(abs(z), ite(z, 1, 0))
     @test isequal(abs(ar), ite(ar >= 0.0, ar, -ar))
 end
+
+@testset "Assignment and conversion" begin
+    @satvariable(aR, Real)
+    @satvariable(a, Int)
+    d = Dict("aR" => 1.0, "a"=>-1)
+    e1 = aR + a <= 0 # this should promote to real
+    e2 = to_int(aR) + a <= 0 # this should be int
+    assign!(e1, d)
+    @test(isa(value(to_real(a)), Float64) && value(to_real(a)) == -1.0)
+    @test(isa(value(to_int(aR)), Integer) && value(to_int(aR)) == 1)
+
+    # Conversion to same type is an identity operation
+    @test(isequal(aR, to_real(aR)))
+    @test(isequal(a, to_int(a)))
+end

--- a/test/int_real_tests.jl
+++ b/test/int_real_tests.jl
@@ -102,6 +102,7 @@ end
     e1 = aR + a <= 0 # this should promote to real
     e2 = to_int(aR) + a <= 0 # this should be int
     assign!(e1, d)
+    assign!(e2, d)
     @test(isa(value(to_real(a)), Float64) && value(to_real(a)) == -1.0)
     @test(isa(value(to_int(aR)), Integer) && value(to_int(aR)) == 1)
 


### PR DESCRIPTION
to_real (and to_int) didn't have method definitions for constants, which caused assign! to crash when assigning values for expressions containing to_real and to_int. Also define to_real(real_expr) and to_int(int_expr) so they return the expr unchanged.