### PR TITLE
improve unit testing via TestItemRunner

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 
 [compat]
 julia = "1"
+TestItemRunner = "1.0"
 z3_jll = "4.13"
 
 [extras]
@@ -15,5 +16,6 @@ test = ["Test"]
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 z3_jll = "1bc4e1ec-7839-5212-8f2f-0d16b7bd09bc"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.2.0"
 
 [compat]
 julia = "1"
-TestItemRunner = "1.0"
 z3_jll = "4.13"
 
 [extras]
@@ -15,7 +14,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [deps]
-Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 z3_jll = "1bc4e1ec-7839-5212-8f2f-0d16b7bd09bc"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+z3_jll = "1bc4e1ec-7839-5212-8f2f-0d16b7bd09bc"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/README_tests.jl
+++ b/test/README_tests.jl
@@ -1,4 +1,4 @@
-#@testitem "README.md exampes" begin
+@testitem "README.md exampes" begin
 
     using Satisfiability
 
@@ -27,4 +27,4 @@
         test_julia_examples_in_markdown("../README.md")
         redirect_stdout(std_)
     end
-#end
+end

--- a/test/README_tests.jl
+++ b/test/README_tests.jl
@@ -1,30 +1,30 @@
-using Satisfiability
-using Test
+#@testitem "README.md exampes" begin
 
-function test_julia_examples_in_markdown(path)
-  file = read(path, String)
-  file_by_code_blocks = split(file, "```julia")[2:end]
-  possible_examples = map(s -> first(split(s, "```")), file_by_code_blocks)
-  for example ∈ possible_examples
-    quote_example = "begin\n" * example * "\nend"
-    parsed =
-      @test_nowarn Meta.parse(quote_example)
-    @test try
-      eval(parsed)
-      true
-    catch e
-      showerror(stderr, e, catch_backtrace())
-      println()
-      false
+    using Satisfiability
+
+    function test_julia_examples_in_markdown(path)
+        file = read(path, String)
+        file_by_code_blocks = split(file, "```julia")[2:end]
+        possible_examples = map(s -> first(split(s, "```")), file_by_code_blocks)
+        for example ∈ possible_examples
+            quote_example = "begin\n" * example * "\nend"
+            parsed = @test_nowarn Meta.parse(quote_example)
+            @test try
+                eval(parsed)
+                true
+            catch e
+                showerror(stderr, e, catch_backtrace())
+                println()
+                false
+            end
+        end
     end
-  end
-end
 
-@testset "Test README.md examples" begin
-  using Satisfiability
-  # Suppress printouts since this only tests that the examples in the README run.
-  std_ = stdout
-  redirect_stdout(devnull)
-  test_julia_examples_in_markdown("../README.md")
-  redirect_stdout(std_)
-end
+    @testset "Test README.md examples" begin
+        # Suppress printouts since this only tests that the examples in the README run.
+        std_ = stdout
+        redirect_stdout(devnull)
+        test_julia_examples_in_markdown("../README.md")
+        redirect_stdout(std_)
+    end
+#end

--- a/test/bitvector_tests.jl
+++ b/test/bitvector_tests.jl
@@ -1,104 +1,103 @@
-using Satisfiability
-using Test
+@testitem "Bitvector" begin
 
-CLEAR_VARNAMES!()
+    using Satisfiability
+    CLEAR_VARNAMES!()
 
-@testset "Construct BitVector variables and exprs" begin
-    # a few basics
-    @test nextsize(16) == UInt16
-    @test nextsize(17) == UInt32
-    @test nextsize(15) == UInt16
-    @test bitcount(0x01) == 1
-    @test bitcount(0b10010) == 5
+    @testset "Construct BitVector variables and exprs" begin
+        # a few basics
+        @test nextsize(16) == UInt16
+        @test nextsize(17) == UInt32
+        @test nextsize(15) == UInt16
+        @test bitcount(0x01) == 1
+        @test bitcount(0b10010) == 5
 
-    @satvariable(a, BitVector, 16)
-    @satvariable(b, BitVector, 16)
-    @satvariable(c, BitVector, 12)
-    @satvariable(d, BitVector, 4)
-    # can make vectors
-    @satvariable(bv[1:2], BitVector, 4)
-    @satvariable(cv[1:2, 1:2], BitVector, 4)
+        @satvariable(a, BitVector, 16)
+        @satvariable(b, BitVector, 16)
+        @satvariable(c, BitVector, 12)
+        @satvariable(d, BitVector, 4)
+        # can make vectors
+        @satvariable(bv[1:2], BitVector, 4)
+        @satvariable(cv[1:2, 1:2], BitVector, 4)
 
-    # unary minus
-    @test (-d).op == :bvneg
-    # combining ops
-    ops = [+, -, *, div, sdiv, urem, <<, >>, srem, smod, >>>, nor, nand, xnor]
-    names = [:bvadd, :bvsub, :bvmul, :bvudiv, :bvsdiv, :bvurem, :bvshl, :bvashr, :bvsrem, :bvsmod, :bvlshr, :bvnor, :bvnand, :bvxnor]
-    for (op, name) in zip(ops, names)
-        @test isequal(op(a,b), BitVectorExpr{UInt16}(name, [a,b], nothing, Satisfiability.__get_hash_name(name, [a,b]), 16))
+        # unary minus
+        @test (-d).op == :bvneg
+        # combining ops
+        ops = [+, -, *, div, sdiv, urem, <<, >>, srem, smod, >>>, nor, nand, xnor]
+        names = [:bvadd, :bvsub, :bvmul, :bvudiv, :bvsdiv, :bvurem, :bvshl, :bvashr, :bvsrem, :bvsmod, :bvlshr, :bvnor, :bvnand, :bvxnor]
+        for (op, name) in zip(ops, names)
+            @test isequal(op(a,b), BitVectorExpr{UInt16}(name, [a,b], nothing, Satisfiability.__get_hash_name(name, [a,b]), 16))
+        end
+
+        # distinct
+        @satvariable(dd[1:3], BitVector, 4)
+        @test isequal(distinct(dd), and(distinct(dd[1], dd[2]), distinct(dd[1], dd[3]), distinct(dd[2], dd[3])))
+
+        # three special cases! the native Julia bitwise ops have weird forms (&)(a,b) because they are short circuitable
+        @test isequal(a & b, BitVectorExpr{UInt16}(:bvand, [a,b], nothing, Satisfiability.__get_hash_name(:bvand, [a,b], is_commutative=true), 16))
+        @test isequal(a | b, BitVectorExpr{UInt16}(:bvor, [a,b], nothing, Satisfiability.__get_hash_name(:bvor, [a,b], is_commutative=true), 16))
+        @test isequal(~a, BitVectorExpr{UInt16}(:bvnot, [a], nothing, Satisfiability.__get_hash_name(:bvnot, [a]), 16))
+
+        # n-ary ops
+        @satvariable(e, BitVector, 16)
+        ops = [+, *, and, or]
+        names = [:bvadd, :bvmul, :bvand, :bvor]
+        ct = Satisfiability.bvconst(0x00ff, 16)
+        for (op, name) in zip(ops, names)
+            @test isequal(op(a,b,0x00ff,e), BitVectorExpr{UInt16}(name, [a,b,ct, e], nothing, Satisfiability.__get_hash_name(name, [a,b,ct,e]), 16))
+        end
+        # works over generator
+        exprs = [a,b,0x00ff,e]
+        @test isequal(xnor(a,b,0x00ff,e), xnor(exprs[i] for i=1:4))
+
+        # logical ops
+        ops = [<, <=, >, >=, ==, slt, sle, sgt, sge]
+        names = [:bvult, :bvule, :bvugt, :bvuge, :eq, :bvslt, :bvsle, :bvsgt, :bvsge]
+        for (op, name) in zip(ops, names)
+            @test isequal(op(a,b), BoolExpr(name, [a,b], nothing, Satisfiability.__get_hash_name(name, [a,b])))
+        end
+
+        # concat
+        @test concat(c, d).length == 16
+        @test (concat(c, d) + a).length == 16
+
+        # indexing
+        @test (a[2:4]).range == UnitRange(2,4)
+        @test_throws ErrorException a[0:2]
+        @test_throws ErrorException a[15:30]
+
+        # bv2int and int2bv
+        @test isequal(bv2int(a), IntExpr(:bv2int, [a], nothing, Satisfiability.__get_hash_name(:bv2int, [a])))
+        @satvariable(e, Int)
+        @test isequal(int2bv(e, 32), BitVectorExpr{UInt32}(:int2bv, [e], nothing, Satisfiability.__get_hash_name(:int2bv, [e]), 32))
     end
 
-    # distinct
-    @satvariable(dd[1:3], BitVector, 4)
-    @test isequal(distinct(dd), and(distinct(dd[1], dd[2]), distinct(dd[1], dd[3]), distinct(dd[2], dd[3])))
+    @testset "Interoperability with constants" begin
+        # underlying helper functions reject invalid values
+        @test_throws ErrorException nextsize(-1)
+        @test_throws ErrorException bitcount(-1)
 
-    # three special cases! the native Julia bitwise ops have weird forms (&)(a,b) because they are short circuitable
-    @test isequal(a & b, BitVectorExpr{UInt16}(:bvand, [a,b], nothing, Satisfiability.__get_hash_name(:bvand, [a,b], is_commutative=true), 16))
-    @test isequal(a | b, BitVectorExpr{UInt16}(:bvor, [a,b], nothing, Satisfiability.__get_hash_name(:bvor, [a,b], is_commutative=true), 16))
-    @test isequal(~a, BitVectorExpr{UInt16}(:bvnot, [a], nothing, Satisfiability.__get_hash_name(:bvnot, [a]), 16))
+        @satvariable(a, BitVector, 8)
+        @satvariable(b, BitVector, 8)
 
-    # n-ary ops
-    @satvariable(e, BitVector, 16)
-    ops = [+, *, and, or]
-    names = [:bvadd, :bvmul, :bvand, :bvor]
-    ct = Satisfiability.bvconst(0x00ff, 16)
-    for (op, name) in zip(ops, names)
-        @test isequal(op(a,b,0x00ff,e), BitVectorExpr{UInt16}(name, [a,b,ct, e], nothing, Satisfiability.__get_hash_name(name, [a,b,ct,e]), 16))
-    end
-    # works over generator
-    exprs = [a,b,0x00ff,e]
-    @test isequal(xnor(a,b,0x00ff,e), xnor(exprs[i] for i=1:4))
+        @test isequal(a + 0xff, 255 + a)
+        @test isequal(b - 0x02, b - 2)
+        @test_throws ErrorException b + -1 + a
 
-    # logical ops
-    ops = [<, <=, >, >=, ==, slt, sle, sgt, sge]
-    names = [:bvult, :bvule, :bvugt, :bvuge, :eq, :bvslt, :bvsle, :bvsgt, :bvsge]
-    for (op, name) in zip(ops, names)
-        @test isequal(op(a,b), BoolExpr(name, [a,b], nothing, Satisfiability.__get_hash_name(name, [a,b])))
+        a.value = 0xff
+        @test concat(bvconst(0x01, 8), bvconst(0x04, 4)).value == 0x014
+        @test isequal(concat(a, 0x1).value, 0x1ff) # because 0x1 is read as one bit
+        @test isequal(concat(a, bvconst(0x01, 8)).value, 0xff01)
+        @test isequal(concat(a, bvconst(0x01, 6)).value, 0b11111111000001)
+
+        @test isequal(0x1 == a, 0x01 == a)
     end
 
-    # concat
-    @test concat(c, d).length == 16
-    @test (concat(c, d) + a).length == 16
+    @testset "Spot checks for SMT generation" begin
+        @test Satisfiability.__format_smt_const(BitVectorExpr, bvconst(0x04, 6)) == "#b000100"
+        @test Satisfiability.__format_smt_const(BitVectorExpr, bvconst(255, 12)) == "#x0ff"
 
-    # indexing
-    @test (a[2:4]).range == UnitRange(2,4)
-    @test_throws ErrorException a[0:2]
-    @test_throws ErrorException a[15:30]
-
-    # bv2int and int2bv
-    @test isequal(bv2int(a), IntExpr(:bv2int, [a], nothing, Satisfiability.__get_hash_name(:bv2int, [a])))
-    @satvariable(e, Int)
-    @test isequal(int2bv(e, 32), BitVectorExpr{UInt32}(:int2bv, [e], nothing, Satisfiability.__get_hash_name(:int2bv, [e]), 32))
-end
-
-@testset "Interoperability with constants" begin
-    # underlying helper functions reject invalid values
-    @test_throws ErrorException nextsize(-1)
-    @test_throws ErrorException bitcount(-1)
-
-    @satvariable(a, BitVector, 8)
-    @satvariable(b, BitVector, 8)
-
-    @test isequal(a + 0xff, 255 + a)
-    @test isequal(b - 0x02, b - 2)
-    @test_throws ErrorException b + -1 + a
-
-    a.value = 0xff
-    @test concat(bvconst(0x01, 8), bvconst(0x04, 4)).value == 0x014
-    @test isequal(concat(a, 0x1).value, 0x1ff) # because 0x1 is read as one bit
-    @test isequal(concat(a, bvconst(0x01, 8)).value, 0xff01)
-    @test isequal(concat(a, bvconst(0x01, 6)).value, 0b11111111000001)
-
-    @test isequal(0x1 == a, 0x01 == a)
-end
-
-@testset "Spot checks for SMT generation" begin
-    
-    @test Satisfiability.__format_smt_const(BitVectorExpr, bvconst(0x04, 6)) == "#b000100"
-    @test Satisfiability.__format_smt_const(BitVectorExpr, bvconst(255, 12)) == "#x0ff"
-
-    @satvariable(a, BitVector, 8)
-    @satvariable(b, BitVector, 8)
+        @satvariable(a, BitVector, 8)
+        @satvariable(b, BitVector, 8)
 
     @test smt(concat(a, b, a), assert=false) ≈ "(declare-fun a () (_ BitVec 8))
 (declare-fun b () (_ BitVec 8))
@@ -112,41 +111,40 @@ end
 
     @test smt(0xff == a) ≈ "(declare-fun a () (_ BitVec 8))
 (assert (= #xff a))\n"
+    end
 
-end
+    @testset "BitVector special cases for SMT generation" begin
+        @satvariable(a, BitVector, 8)
+        @satvariable(b, BitVector, 8)
 
-@testset "BitVector special cases for SMT generation" begin
-    @satvariable(a, BitVector, 8)
-    @satvariable(b, BitVector, 8)
-
-    @satvariable(c, Int)
-    @test smt(int2bv(c, 64), assert=false) ≈ "(declare-fun c () Int)
+        @satvariable(c, Int)
+        @test smt(int2bv(c, 64), assert=false) ≈ "(declare-fun c () Int)
 (define-fun int2bv_1a6e7a9c3b2f1483 () (_ BitVec 64) ((_ int2bv 64) (as c Int)))\n"
 
-    @test smt(bv2int(b) < 1) ≈ "(declare-fun b () (_ BitVec 8))
+        @test smt(bv2int(b) < 1) ≈ "(declare-fun b () (_ BitVec 8))
 (assert (< (bv2int b) 1))\n"
 
-    @test smt(a[1:8] == 0xff) ≈ "(declare-fun a () (_ BitVec 8))
+        @test smt(a[1:8] == 0xff) ≈ "(declare-fun a () (_ BitVec 8))
 (assert (= ((_ extract 7 0) a) #xff))\n"
 
-    @satvariable(x, BitVector, 8)
-    @test smt(repeat(x,2) == 0xff) ≈ "(declare-fun x () (_ BitVec 8))
+        @satvariable(x, BitVector, 8)
+        @test smt(repeat(x,2) == 0xff) ≈ "(declare-fun x () (_ BitVec 8))
 (assert (= (concat x x) #x00ff))\n"
 
-    @test smt(zero_extend(x,4) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
+        @test smt(zero_extend(x,4) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
 (assert (= ((_ zero_extend 4) x) #x000))\n"
-    @test smt(sign_extend(x,4) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
+        @test smt(sign_extend(x,4) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
 (assert (= ((_ sign_extend 4) x) #x000))\n"
 
-    @test smt(rotate_left(x,2) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
+        @test smt(rotate_left(x,2) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
 (assert (= ((_ rotate_left 2) x) #x00))\n"
-    @test smt(rotate_right(x,2) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
+        @test smt(rotate_right(x,2) == 0x0) ≈ "(declare-fun x () (_ BitVec 8))
 (assert (= ((_ rotate_right 2) x) #x00))\n"
-end
+    end
 
-@testset "BitVector result parsing" begin
-    # this output is the result of the two prior tests, bv2int(b) < 1 and a[1:8] == 0xff
-    output = "(
+    @testset "BitVector result parsing" begin
+        # this output is the result of the two prior tests, bv2int(b) < 1 and a[1:8] == 0xff
+        output = "(
     (define-fun b () (_ BitVec 8)
       #x00)
     (define-fun bv2int_9551acae52440d48 () Int
@@ -160,58 +158,58 @@ end
     (define-fun a () (_ BitVec 8)
       #xff)
   )"
-    @satvariable(a, BitVector, 8)
-    @satvariable(b, BitVector, 8)
-    expr = and(a[1:8] == 0xff, bv2int(b) < 1)
-    vals = Satisfiability.parse_model(output)
-    Satisfiability.assign!(expr, vals)
-    @test a.value == 0xff
-    @test b.value == 0x00
+        @satvariable(a, BitVector, 8)
+        @satvariable(b, BitVector, 8)
+        expr = and(a[1:8] == 0xff, bv2int(b) < 1)
+        vals = Satisfiability.parse_model(output)
+        Satisfiability.assign!(expr, vals)
+        @test a.value == 0xff
+        @test b.value == 0x00
+    end
 
-end
+    @testset "Assigning values" begin
+        assign! = Satisfiability.assign!
+        @satvariable(a, BitVector, 8)
+        @satvariable(b, BitVector, 8)
+        values = Dict("a" => 0x01, "b" => 0xf0)
 
-@testset "Assigning values" begin
-    assign! = Satisfiability.assign!
-    @satvariable(a, BitVector, 8)
-    @satvariable(b, BitVector, 8)
-    values = Dict("a" => 0x01, "b" => 0xf0)
+        expr = a | b; assign!(expr, values)
+        @test expr.value == 0xf1
 
-    expr = a | b; assign!(expr, values)
-    @test expr.value == 0xf1
+        expr = -a - b; assign!(expr, values)
+        @test expr.value == -0xf1
 
-    expr = -a - b; assign!(expr, values)
-    @test expr.value == -0xf1
+        expr = div(b,a); assign!(expr, values)
+        @test expr.value == 0xf0
 
-    expr = div(b,a); assign!(expr, values)
-    @test expr.value == 0xf0
+        expr = sdiv(-b,a); assign!(expr, values)
+        @test expr.value == div(-0xf0, 0x01)
 
-    expr = sdiv(-b,a); assign!(expr, values)
-    @test expr.value == div(-0xf0, 0x01)
+        expr = repeat(a, 3); assign!(expr, values)
+        @test expr.value == 0x010101
 
-    expr = repeat(a, 3); assign!(expr, values)
-    @test expr.value == 0x010101
+        expr = repeat(0xf0, 3)
+        @test expr == 0xf0f0f0
 
-    expr = repeat(0xf0, 3)
-    @test expr == 0xf0f0f0
+        expr = zero_extend(a, 4); assign!(expr, values)
+        @test expr.value == 0x0001
+        @test_throws ErrorException zero_extend(a, -2)
 
-    expr = zero_extend(a, 4); assign!(expr, values)
-    @test expr.value == 0x0001
-    @test_throws ErrorException zero_extend(a, -2)
+        expr = sign_extend(-a, 4); assign!(expr, values)
+        @test expr.value == 0xffff
+        @test_throws ErrorException sign_extend(a, -2)
 
-    expr = sign_extend(-a, 4); assign!(expr, values)
-    @test expr.value == 0xffff
-    @test_throws ErrorException sign_extend(a, -2)
+        expr = rotate_left(b, 4); assign!(expr, values)
+        @test expr.value == 0x0f
+        @test_throws ErrorException rotate_left(a, -2)
 
-    expr = rotate_left(b, 4); assign!(expr, values)
-    @test expr.value == 0x0f
-    @test_throws ErrorException rotate_left(a, -2)
+        expr = rotate_right(b, 4); assign!(expr, values)
+        @test expr.value == 0x0f
+        @test_throws ErrorException rotate_right(a, -2)
 
-    expr = rotate_right(b, 4); assign!(expr, values)
-    @test expr.value == 0x0f
-    @test_throws ErrorException rotate_right(a, -2)
-
-    expr = bvcomp(a,a); assign!(expr, values)
-    @test expr.value == 0b1
-    expr = bvcomp(a,b); assign!(expr, values)
-    @test expr.value == 0b0
+        expr = bvcomp(a,a); assign!(expr, values)
+        @test expr.value == 0b1
+        expr = bvcomp(a,b); assign!(expr, values)
+        @test expr.value == 0b0
+    end
 end

--- a/test/boolean_operation_tests.jl
+++ b/test/boolean_operation_tests.jl
@@ -1,189 +1,191 @@
-using Satisfiability
-using Test
+@testitem "Boolean Operation" begin
 
-@testset "Construct variables" begin
-    # Write your tests here.
-    @satvariable(z1, Bool)
-    @test size(z1) == 1
-    
-    @satvariable(z32[1:3, 1:2], Bool)
-    @test isa(z32,Array{BoolExpr})
-    @test size(z32) == (3,2)
+    using Satisfiability
 
-    @satvariable(z23[1:2,1:3], Bool)
+    @testset "Construct variables" begin
+        # Write your tests here.
+        @satvariable(z1, Bool)
+        @test size(z1) == 1
+        
+        @satvariable(z32[1:3, 1:2], Bool)
+        @test isa(z32,Array{BoolExpr})
+        @test size(z32) == (3,2)
 
-    # Sizes are broadcastable
-    @satvariable(z12[1:1,1:2], Bool)
-    @satvariable(z21[1:2,1:1], Bool)
-    # (1,) broadcasts with (1,2)
-    @test all(size(z1 .∨ z12) .== (1,2))
-    # (1,) broadcasts with (2,3)
-    @test all(size(z1 .∨ z32) .== (3,2))
-    # (1,2) broadcasts with (3,2)
-    @test all(size(z12 .∧ z32) .== (3,2))
-    # (2,1) broadcasts with (2,3)
-    @test all(size(z21 .∧ z23) .== (2,3))
+        @satvariable(z23[1:2,1:3], Bool)
 
-    # Wrong sizes aren't broadcastable
-    # (1,2) doesn't broadcast with (2,3)
-    @test_throws DimensionMismatch z12 .∧ z23
-    # (2,3) doesn't broadcast with (3,2)
-    @test_throws DimensionMismatch z32 .∨ z23
+        # Sizes are broadcastable
+        @satvariable(z12[1:1,1:2], Bool)
+        @satvariable(z21[1:2,1:1], Bool)
+        # (1,) broadcasts with (1,2)
+        @test all(size(z1 .∨ z12) .== (1,2))
+        # (1,) broadcasts with (2,3)
+        @test all(size(z1 .∨ z32) .== (3,2))
+        # (1,2) broadcasts with (3,2)
+        @test all(size(z12 .∧ z32) .== (3,2))
+        # (2,1) broadcasts with (2,3)
+        @test all(size(z21 .∧ z23) .== (2,3))
 
-    # Nested wrong sizes also aren't broadcastable
-    @test_throws DimensionMismatch (z1.∨z23) .∨ z32
+        # Wrong sizes aren't broadcastable
+        # (1,2) doesn't broadcast with (2,3)
+        @test_throws DimensionMismatch z12 .∧ z23
+        # (2,3) doesn't broadcast with (3,2)
+        @test_throws DimensionMismatch z32 .∨ z23
 
-    # printing works
-    @satvariable(z, Bool)
-    @test string(not(z)) == "not_25ec308d1df79cdc\n | z\n"
-end
+        # Nested wrong sizes also aren't broadcastable
+        @test_throws DimensionMismatch (z1.∨z23) .∨ z32
 
-@testset "Print variables" begin
-    @satvariable(α[1:2, 1:3], Bool)
-    string_α = "BoolExpr[α_1_1\n α_1_2\n α_1_3\n; α_2_1\n α_2_2\n α_2_3\n]"
-    @test string(α) == string_α
-    
-    @satvariable(z1, Bool)
-    z1.value = true
-    @test string(z1) == "z1 = true\n"
-end
+        # printing works
+        @satvariable(z, Bool)
+        @test string(not(z)) == "not_25ec308d1df79cdc\n | z\n"
+    end
 
-@testset "Logical operations" begin    
-    @satvariable(z1[1:1], Bool)
-    @satvariable(z12[1:1, 1:2], Bool)
-    @satvariable(z32[1:3, 1:2], Bool)
+    @testset "Print variables" begin
+        @satvariable(α[1:2, 1:3], Bool)
+        string_α = "BoolExpr[α_1_1\n α_1_2\n α_1_3\n; α_2_1\n α_2_2\n α_2_3\n]"
+        @test string(α) == string_α
+        
+        @satvariable(z1, Bool)
+        z1.value = true
+        @test string(z1) == "z1 = true\n"
+    end
 
-    # 1 and 0 cases
-    @test isequal(and([z1[1]]), z1[1])
-    @test_throws ErrorException and(AbstractExpr[])
-    
-	# Can construct with 2 exprs
-    @test Satisfiability.__is_permutation((z1 .∧ z32)[1].children, [z1[1], z32[1]] )
-    @test  (z1 .∧ z32)[1].name == Satisfiability.__get_hash_name(:and, [z1[1], z32[1]], is_commutative=true)
-    @test Satisfiability.__is_permutation((z1 .∨ z32)[2,1].children, [z1[1], z32[2,1]] )
-    @test  (z1 .∨ z32)[1].name == Satisfiability.__get_hash_name(:or, [z1[1], z32[1]], is_commutative=true)
+    @testset "Logical operations" begin
+        @satvariable(z1[1:1], Bool)
+        @satvariable(z12[1:1, 1:2], Bool)
+        @satvariable(z32[1:3, 1:2], Bool)
 
-    # Can construct with N>2 exprs
-    or_N = or.(z1, z12, z32)
-    and_N = and.(z1, z12, z32)
+        # 1 and 0 cases
+        @test isequal(and([z1[1]]), z1[1])
+        @test_throws ErrorException and(AbstractExpr[])
 
-    @test Satisfiability.__is_permutation(or_N[3,2].children, [z1[1], z12[1,2], z32[3,2]] )
-    exprs = [z1[1], z12[1], z32[1]]
-    @test  and_N[1].name == and(e for e in exprs).name
+        # Can construct with 2 exprs
+        @test Satisfiability.__is_permutation((z1 .∧ z32)[1].children, [z1[1], z32[1]] )
+        @test  (z1 .∧ z32)[1].name == Satisfiability.__get_hash_name(:and, [z1[1], z32[1]], is_commutative=true)
+        @test Satisfiability.__is_permutation((z1 .∨ z32)[2,1].children, [z1[1], z32[2,1]] )
+        @test  (z1 .∨ z32)[1].name == Satisfiability.__get_hash_name(:or, [z1[1], z32[1]], is_commutative=true)
 
-    @test Satisfiability.__is_permutation(or_N[1].children, [z1[1], z12[1], z32[1]] )
-	@test or_N[1].name == or(e for e in exprs).name
-    
-    # Can construct negation
-    @test isequal((not(z32))[1].children, [z32[1]])
-    # negation of equality simplifies to distinct when it's a 2-op
-    @satvariable(a3[1:3], Bool)
-    @test isequal(¬(a3[1]==a3[2]), distinct(a3[1:2]))
-    # and doesn't when it's a n>2-op
-    @test isequal((¬a3[1]).op, :not)
-    # this tests the generator syntax
-    @test isequal(distinct(a3), distinct(a3[i] for i=1:3))
+        # Can construct with N>2 exprs
+        or_N = or.(z1, z12, z32)
+        and_N = and.(z1, z12, z32)
 
-    # Can construct Implies
-    @test isequal((z1 .⟹ z1)[1].children, [z1[1], z1[1]])
+        @test Satisfiability.__is_permutation(or_N[3,2].children, [z1[1], z12[1,2], z32[3,2]] )
+        exprs = [z1[1], z12[1], z32[1]]
+        @test  and_N[1].name == and(e for e in exprs).name
 
-    # Can construct == and distinct
-    @test isequal(z1[1] == true, true == z1[1])
-    @test isequal(z1[1] != z12[1], z12[1] != z1[1])
-    @test isequal(distinct(z12), and(distinct(z12[1,1], z12[1,2])))
- end
+        @test Satisfiability.__is_permutation(or_N[1].children, [z1[1], z12[1], z32[1]] )
+         @test or_N[1].name == or(e for e in exprs).name
 
-@testset "Additional operations" begin
-    @satvariable(z, Bool)
-    @satvariable(z1[1:1], Bool)
-    @satvariable(z12[1:1, 1:2], Bool)
+        # Can construct negation
+        @test isequal((not(z32))[1].children, [z32[1]])
+        # negation of equality simplifies to distinct when it's a 2-op
+        @satvariable(a3[1:3], Bool)
+        @test isequal(¬(a3[1]==a3[2]), distinct(a3[1:2]))
+        # and doesn't when it's a n>2-op
+        @test isequal((¬a3[1]).op, :not)
+        # this tests the generator syntax
+        @test isequal(distinct(a3), distinct(a3[i] for i=1:3))
 
-    # xor
-    @test all(isequal.(xor.(z1, z12), BoolExpr[xor(z12[1,1], z1[1]) xor(z12[1,2], z1[1])]))
-    # weird cases
-    @test_throws ErrorException xor(AbstractExpr[])
-    @test all(isequal.(xor(z1), z1))
-    @test xor(true, true, z) == false
-    @test xor(true, false) == true
+        # Can construct Implies
+        @test isequal((z1 .⟹ z1)[1].children, [z1[1], z1[1]])
 
-    # n case
-    @test all(isequal.(xor.(z, z1, z12), BoolExpr[xor(z, z1[1], z12[1,1]) xor(z, z1[1], z12[1,2])]))
+        # Can construct == and distinct
+        @test isequal(z1[1] == true, true == z1[1])
+        @test isequal(z1[1] != z12[1], z12[1] != z1[1])
+        @test isequal(distinct(z12), and(distinct(z12[1,1], z12[1,2])))
+    end
 
-    # iff
-    @test all(isequal.(iff.(z1, z12), BoolExpr[ iff(z1[1], z12[1,1]) iff(z1[1], z12[1,2]) ]))
+    @testset "Additional operations" begin
+        @satvariable(z, Bool)
+        @satvariable(z1[1:1], Bool)
+        @satvariable(z12[1:1, 1:2], Bool)
 
-    # ite (if-then-else)
-    @test all(isequal.( ite.(z,z1, z12), BoolExpr[ ite(z, z1[1], z12[1,1]) ite(z, z1[1], z12[1,2]) ]))
+        # xor
+        @test all(isequal.(xor.(z1, z12), BoolExpr[xor(z12[1,1], z1[1]) xor(z12[1,2], z1[1])]))
+        # weird cases
+        @test_throws ErrorException xor(AbstractExpr[])
+        @test all(isequal.(xor(z1), z1))
+        @test xor(true, true, z) == false
+        @test xor(true, false) == true
 
-    # mixed and and or doesn't flatten
-    @test isequal(and([or(z, z1[1]), and(z, true)]), and(or(z, z1[1]), z))
-    @test isequal(or([and(z, z1[1]), or(z, false)]), or(and(z, z1[1]), z))
-end
+        # n case
+        @test all(isequal.(xor.(z, z1, z12), BoolExpr[xor(z, z1[1], z12[1,1]) xor(z, z1[1], z12[1,2])]))
 
-@testset "Operations with 1D literals and 1D exprs" begin
-    @satvariable(z, Bool)
+        # iff
+        @test all(isequal.(iff.(z1, z12), BoolExpr[ iff(z1[1], z12[1,1]) iff(z1[1], z12[1,2]) ]))
 
-    # Can operate on all literals
-    @test all([not(false), ¬(¬(true))])
-    @test ∧(true, true)
-    @test ∨(true, false)
-    @test ⟹(false, false)
+        # ite (if-then-else)
+        @test all(isequal.( ite.(z,z1, z12), BoolExpr[ ite(z, z1[1], z12[1,1]) ite(z, z1[1], z12[1,2]) ]))
 
-    # Can operate on mixed literals and BoolExprs
-    @test isequal(and(true, z), z)
-    @test z ∧ false == false
-    @test true ∨ z == true
-    @test isequal(or(z, false, false), z)
-    @test isequal(implies(z, false), ¬z) #or(¬z, false) == ¬z
-    @test isequal(true ⟹ z, z)
-end
+        # mixed and and or doesn't flatten
+        @test isequal(and([or(z, z1[1]), and(z, true)]), and(or(z, z1[1]), z))
+        @test isequal(or([and(z, z1[1]), or(z, false)]), or(and(z, z1[1]), z))
+    end
 
-@testset "Operations with 1D literals and nxm exprs" begin
-    @satvariable(z[1:2, 1:3], Bool)
+    @testset "Operations with 1D literals and 1D exprs" begin
+        @satvariable(z, Bool)
 
-    # Can operate on mixed literals and BoolExprs
-    @test isequal(true .∧ z, z)
-    @test and.(z, false) == [false false false; false false false]
-    @test z .∨ true == [true true true; true true true]
-    @test isequal(or.(z, false, false), z)
-    @test isequal(implies.(z, false), ¬z) #or(¬z, false) == ¬z
-    @test isequal(implies.(true, z), z)
-end
+        # Can operate on all literals
+        @test all([not(false), ¬(¬(true))])
+        @test ∧(true, true)
+        @test ∨(true, false)
+        @test ⟹(false, false)
 
-@testset "Operations with nxm literals and nxm exprs" begin
-    A = [true false false; false true true]
-    B = [true true true; true true true]
-    @satvariable(z1, Bool)
-    @satvariable(z[1:2, 1:3], Bool)
+        # Can operate on mixed literals and BoolExprs
+        @test isequal(and(true, z), z)
+        @test z ∧ false == false
+        @test true ∨ z == true
+        @test isequal(or(z, false, false), z)
+        @test isequal(implies(z, false), ¬z) #or(¬z, false) == ¬z
+        @test isequal(true ⟹ z, z)
+    end
 
-    # Can operate on all literal matrices
-    @test any([not(BitArray(A)); ¬(¬(A))])
-    @test all(or.(A, A) .== A)
-    @test all(or.(false, A) .== A)
-    @test all(implies.(A, B))
+    @testset "Operations with 1D literals and nxm exprs" begin
+        @satvariable(z[1:2, 1:3], Bool)
 
-    # Can operate on mixed literals and BoolExprs
-    @test all(isequal.(and.(B, z), z))
-    @test all(isequal.(or.(¬B, z), z))
-    @test all(or.(z, B, false) .== B)
-    @test all(isequal.(implies.(z, ¬B), ¬z))
-    @test all(isequal.(implies.(z, false), ¬z))
+        # Can operate on mixed literals and BoolExprs
+        @test isequal(true .∧ z, z)
+        @test and.(z, false) == [false false false; false false false]
+        @test z .∨ true == [true true true; true true true]
+        @test isequal(or.(z, false, false), z)
+        @test isequal(implies.(z, false), ¬z) #or(¬z, false) == ¬z
+        @test isequal(implies.(true, z), z)
+    end
 
-    @test all(isequal.(and.(A, z1), [z1 false false; false z1 z1]))
-    @test all(isequal.(or.(z1, A), [true z1 z1; z1 true true]))
-end
+    @testset "Operations with nxm literals and nxm exprs" begin
+        A = [true false false; false true true]
+        B = [true true true; true true true]
+        @satvariable(z1, Bool)
+        @satvariable(z[1:2, 1:3], Bool)
 
-@testset "More operations with literals" begin
-    A = [true false false; false true true]
-    @satvariable(z[1:1], Bool)
-    @test !any(xor.(A, A)) # all false
-    @test all(isequal.(xor.(A, z), [¬z z z; z ¬z ¬z]))
+        # Can operate on all literal matrices
+        @test any([not(BitArray(A)); ¬(¬(A))])
+        @test all(or.(A, A) .== A)
+        @test all(or.(false, A) .== A)
+        @test all(implies.(A, B))
 
-    @test all(iff.(A, A))
-    @test all(isequal.(iff.(A, z), [z ¬z ¬z; ¬z z z]))
-    @test all(isequal.(iff.(z, A), iff.(A, z)))
+        # Can operate on mixed literals and BoolExprs
+        @test all(isequal.(and.(B, z), z))
+        @test all(isequal.(or.(¬B, z), z))
+        @test all(or.(z, B, false) .== B)
+        @test all(isequal.(implies.(z, ¬B), ¬z))
+        @test all(isequal.(implies.(z, false), ¬z))
 
-    y = @satvariable(y[1:1], Bool)
-    @test all(isequal.(ite.(true, z, y), z ))
-    @test all(isequal.(ite.(false, true, y), y ))
+        @test all(isequal.(and.(A, z1), [z1 false false; false z1 z1]))
+        @test all(isequal.(or.(z1, A), [true z1 z1; z1 true true]))
+    end
+
+    @testset "More operations with literals" begin
+        A = [true false false; false true true]
+        @satvariable(z[1:1], Bool)
+        @test !any(xor.(A, A)) # all false
+        @test all(isequal.(xor.(A, z), [¬z z z; z ¬z ¬z]))
+
+        @test all(iff.(A, A))
+        @test all(isequal.(iff.(A, z), [z ¬z ¬z; ¬z z z]))
+        @test all(isequal.(iff.(z, A), iff.(A, z)))
+
+        y = @satvariable(y[1:1], Bool)
+        @test all(isequal.(ite.(true, z, y), z ))
+        @test all(isequal.(ite.(false, true, y), y ))
+    end
 end

--- a/test/extra_tests.jl
+++ b/test/extra_tests.jl
@@ -1,0 +1,23 @@
+@testitem "Extra" begin
+
+    using Logging
+    using Satisfiability
+
+    # Extra: Check that defining duplicate variables yields a warning
+    @info("Check that redefining a variable yields a warning. One warning will be emitted.")
+    @testset "Duplicate variable warning" begin
+        SET_DUPLICATE_NAME_WARNING!(true)
+        @satvariable(z, Bool)
+        @test_logs (:warn, "Duplicate variable name z of type Bool") @satvariable(z, Bool)
+
+        # now we should have no warnings
+        SET_DUPLICATE_NAME_WARNING!(false)
+        @test_logs min_level = Logging.Warn @satvariable(z, Bool)
+
+        # we can also clear the list
+        SET_DUPLICATE_NAME_WARNING!(true)
+        CLEAR_VARNAMES!()
+        @test_logs min_level = Logging.Warn @satvariable(z, Bool)
+        SET_DUPLICATE_NAME_WARNING!(false)
+   end
+end

--- a/test/int_real_tests.jl
+++ b/test/int_real_tests.jl
@@ -1,112 +1,114 @@
-using Satisfiability
-using Test
+@testitem "Int Real" begin
 
-@testset "Construct Int and Real expressions" begin
-    @satvariable(a, Int)
-    @satvariable(b[1:2], Int)
-    @satvariable(c[1:1,1:2], Int)
+    using Satisfiability
 
-    @satvariable(ar, Real)
-    @satvariable(br[1:2], Real)
-    @satvariable(cr[1:1,1:2], Real)
+    @testset "Construct Int and Real expressions" begin
+        @satvariable(a, Int)
+        @satvariable(b[1:2], Int)
+        @satvariable(c[1:1,1:2], Int)
 
-    @satvariable(z, Bool)
-    @test isequal(convert(IntExpr, z), ite(z, 1, 0))
-    @test isequal(convert(RealExpr, z), ite(z, 1.0, 0.0))
-    @test isequal(z+z, ite(z, 1, 0) + ite(z, 1, 0))
+        @satvariable(ar, Real)
+        @satvariable(br[1:2], Real)
+        @satvariable(cr[1:1,1:2], Real)
 
-    a.value = 2; b[1].value = 1
-    @test isequal((a .< b)[1], BoolExpr(:lt, AbstractExpr[a, b[1]], false, Satisfiability.__get_hash_name(:lt, [a,b[1]])))
-    @test isequal((a .>= b)[1], BoolExpr(:geq, AbstractExpr[a, b[1]], true, Satisfiability.__get_hash_name(:geq, [a,b[1]])))
+        @satvariable(z, Bool)
+        @test isequal(convert(IntExpr, z), ite(z, 1, 0))
+        @test isequal(convert(RealExpr, z), ite(z, 1.0, 0.0))
+        @test isequal(z+z, ite(z, 1, 0) + ite(z, 1, 0))
 
-    ar.value = 2.1; br[1].value = 0.9
-    @test isequal((ar .> br)[1], BoolExpr(:gt, AbstractExpr[ar, br[1]], true, Satisfiability.__get_hash_name(:gt, [ar,br[1]])))
-    @test isequal((ar .<= br)[1], BoolExpr(:leq, AbstractExpr[ar, br[1]], false, Satisfiability.__get_hash_name(:leq, [ar,br[1]])))
+        a.value = 2; b[1].value = 1
+        @test isequal((a .< b)[1], BoolExpr(:lt, AbstractExpr[a, b[1]], false, Satisfiability.__get_hash_name(:lt, [a,b[1]])))
+        @test isequal((a .>= b)[1], BoolExpr(:geq, AbstractExpr[a, b[1]], true, Satisfiability.__get_hash_name(:geq, [a,b[1]])))
 
-    @test isequal((-c)[1,2], IntExpr(:neg, [c[1,2]], nothing, Satisfiability.__get_hash_name(:neg, [c[1,2]])))
-    @test isequal((-cr)[1,2], RealExpr(:neg, [cr[1,2]], nothing, Satisfiability.__get_hash_name(:neg, [cr[1,2]])))
+        ar.value = 2.1; br[1].value = 0.9
+        @test isequal((ar .> br)[1], BoolExpr(:gt, AbstractExpr[ar, br[1]], true, Satisfiability.__get_hash_name(:gt, [ar,br[1]])))
+        @test isequal((ar .<= br)[1], BoolExpr(:leq, AbstractExpr[ar, br[1]], false, Satisfiability.__get_hash_name(:leq, [ar,br[1]])))
 
-    # Construct with constants on RHS
-    c[1,2].value = 1
-    c[1,1].value = 0
-    @test isequal((cr .>= 0)[1,1] , cr[1,1] >= 0) && isequal((cr .<= 0.0)[1,1] , cr[1,1] <= 0.0)
-    @test isequal((cr .== false)[1,1] , cr[1,1] == false)
-    @test isequal((cr .< false)[1,1] , cr[1,1] < false) && isequal((cr .> 0)[1,1] , cr[1,1] > 0)
+        @test isequal((-c)[1,2], IntExpr(:neg, [c[1,2]], nothing, Satisfiability.__get_hash_name(:neg, [c[1,2]])))
+        @test isequal((-cr)[1,2], RealExpr(:neg, [cr[1,2]], nothing, Satisfiability.__get_hash_name(:neg, [cr[1,2]])))
 
-    
-    # Construct with constants on LHS
-    @test isequal((0 .>= c)[1,1] , 0 >= c[1,1]) && isequal((0.0 .<= c)[1,1] , 0.0 <= c[1,1])
-    @test isequal((0 .== c)[1,1] , c[1,1] == 0)
-    @test isequal((0 .< c)[1,1] , 0 < c[1,1]) && isequal((0 .> c)[1,1] , 0 > c[1,1])
-    @test isequal((1 .- c)[1,1], 1 - c[1,1]) && isequal((2 .* c)[1,1], c[1,1] * 2) && isequal((2 ./ br)[1], 2 / br[1])
+        # Construct with constants on RHS
+        c[1,2].value = 1
+        c[1,1].value = 0
+        @test isequal((cr .>= 0)[1,1] , cr[1,1] >= 0) && isequal((cr .<= 0.0)[1,1] , cr[1,1] <= 0.0)
+        @test isequal((cr .== false)[1,1] , cr[1,1] == false)
+        @test isequal((cr .< false)[1,1] , cr[1,1] < false) && isequal((cr .> 0)[1,1] , cr[1,1] > 0)
 
-    # distinct
-    @test isequal(distinct(c[1,2], c[1,1]), c[1,2] != c[1,1])
-    @test distinct(3,4) && !distinct(true, true)
-    @test isequal(distinct(b), distinct(b[2], b[1]))
-    @test isequal(distinct(ar, 2), distinct(ar, 2.0))
-end
 
-@testset "Construct n-ary ops" begin
-    @satvariable(α, Int)
-    @satvariable(b[1:2], Int)
-    @satvariable(αr, Real)
-    @satvariable(br[1:2], Real)
+        # Construct with constants on LHS
+        @test isequal((0 .>= c)[1,1] , 0 >= c[1,1]) && isequal((0.0 .<= c)[1,1] , 0.0 <= c[1,1])
+        @test isequal((0 .== c)[1,1] , c[1,1] == 0)
+        @test isequal((0 .< c)[1,1] , 0 < c[1,1]) && isequal((0 .> c)[1,1] , 0 > c[1,1])
+        @test isequal((1 .- c)[1,1], 1 - c[1,1]) && isequal((2 .* c)[1,1], c[1,1] * 2) && isequal((2 ./ br)[1], 2 / br[1])
 
-    # Operations with expressions only
-    @test all(isa.(α .+ b, IntExpr))
-    @test all(isa.(b .- α, IntExpr))
-    @test all(isa.(br .* αr, RealExpr))
-    @test all(isa.(α ./ b, RealExpr))
+        # distinct
+        @test isequal(distinct(c[1,2], c[1,1]), c[1,2] != c[1,1])
+        @test distinct(3,4) && !distinct(true, true)
+        @test isequal(distinct(b), distinct(b[2], b[1]))
+        @test isequal(distinct(ar, 2), distinct(ar, 2.0))
+    end
 
-    @test isequal(α*α*α, α^3)
-    @test isequal(α^(-1), 1.0/to_real(α))
-    @test isequal((1.0/αr)*(1.0/αr), αr^(-2))
+    @testset "Construct n-ary ops" begin
+        @satvariable(α, Int)
+        @satvariable(b[1:2], Int)
+        @satvariable(αr, Real)
+        @satvariable(br[1:2], Real)
 
-    # Operations with mixed constants and type promotion
-    # Adding Int and Bool types results in an IntExpr
-    children = [α, IntExpr(:const, AbstractExpr[], 2, "const_2")]
-    @test isequal(sum([α, 1, true]), IntExpr(:add, children, nothing, Satisfiability.__get_hash_name(:add, children, is_commutative=true)))
-    
-    # Type promotion to RealExpr works when we add a float-valued literal
-    children = [α, RealExpr(:const, AbstractExpr[], 3., "const_3.0")]
-    @test isequal(sum([1.0, α, true, 1]), RealExpr(:add, children, nothing, Satisfiability.__get_hash_name(:add, children, is_commutative=true)))
+        # Operations with expressions only
+        @test all(isa.(α .+ b, IntExpr))
+        @test all(isa.(b .- α, IntExpr))
+        @test all(isa.(br .* αr, RealExpr))
+        @test all(isa.(α ./ b, RealExpr))
 
-    # Type promotion to RealExpr works when we add a real-valued expr
-    children = [to_real(α), to_real(b[1]), RealExpr(:const, AbstractExpr[], 2.0, "const_2.0")]
-    @test isequal(sum([α, 1.0, 1, false, b[1]]), RealExpr(:add, children, nothing, Satisfiability.__get_hash_name(:add, children, is_commutative=true)))
+        @test isequal(α*α*α, α^3)
+        @test isequal(α^(-1), 1.0/to_real(α))
+        @test isequal((1.0/αr)*(1.0/αr), αr^(-2))
 
-    # Sum works automatically
-    @test isequal(1 + div(α, b[1]) + mod(b[1], b[2]) + true, sum([1, div(α, b[1]), mod(b[1], b[2]), true]))
+        # Operations with mixed constants and type promotion
+        # Adding Int and Bool types results in an IntExpr
+        children = [α, IntExpr(:const, AbstractExpr[], 2, "const_2")]
+        @test isequal(sum([α, 1, true]), IntExpr(:add, children, nothing, Satisfiability.__get_hash_name(:add, children, is_commutative=true)))
+        
+        # Type promotion to RealExpr works when we add a float-valued literal
+        children = [α, RealExpr(:const, AbstractExpr[], 3., "const_3.0")]
+        @test isequal(sum([1.0, α, true, 1]), RealExpr(:add, children, nothing, Satisfiability.__get_hash_name(:add, children, is_commutative=true)))
 
-    @test all(isequal.((α - 3).children, [α, IntExpr(:const, AbstractExpr[], 3, "const_3")]))
-    @test all(isequal.((αr/3.0).children, [αr, RealExpr(:const, AbstractExpr[], 3., "const_3.0")]))
+        # Type promotion to RealExpr works when we add a real-valued expr
+        children = [to_real(α), to_real(b[1]), RealExpr(:const, AbstractExpr[], 2.0, "const_2.0")]
+        @test isequal(sum([α, 1.0, 1, false, b[1]]), RealExpr(:add, children, nothing, Satisfiability.__get_hash_name(:add, children, is_commutative=true)))
 
-    # div, /, mod type coercion
-    @test isequal(div(2.0, αr), div(2, to_int(αr)))
-    @test isequal(div(αr, 2.0), div(to_int(αr), 2))
-    @test isequal(mod(αr, 3.0), mod(to_int(αr), 3))
-    @test isequal(mod(3.0, αr), mod(3, to_int(αr)))
-    @test isequal(α/2, to_real(α)/2.0)
+        # Sum works automatically
+        @test isequal(1 + div(α, b[1]) + mod(b[1], b[2]) + true, sum([1, div(α, b[1]), mod(b[1], b[2]), true]))
 
-    # abs rewrites to ite for non-int variables
-    @satvariable(z, Bool)
-    @test isequal(abs(z), ite(z, 1, 0))
-    @test isequal(abs(αr), ite(αr >= 0.0, αr, -αr))
-end
+        @test all(isequal.((α - 3).children, [α, IntExpr(:const, AbstractExpr[], 3, "const_3")]))
+        @test all(isequal.((αr/3.0).children, [αr, RealExpr(:const, AbstractExpr[], 3., "const_3.0")]))
 
-@testset "Assignment and conversion" begin
-    @satvariable(aR, Real)
-    @satvariable(a, Int)
-    d = Dict("aR" => 1.0, "a"=>-1)
-    e1 = aR + a <= 0 # this should promote to real
-    e2 = to_int(aR) + a <= 0 # this should be int
-    assign!(e1, d)
-    assign!(e2, d)
-    @test(isa(value(to_real(a)), Float64) && value(to_real(a)) == -1.0)
-    @test(isa(value(to_int(aR)), Integer) && value(to_int(aR)) == 1)
+        # div, /, mod type coercion
+        @test isequal(div(2.0, αr), div(2, to_int(αr)))
+        @test isequal(div(αr, 2.0), div(to_int(αr), 2))
+        @test isequal(mod(αr, 3.0), mod(to_int(αr), 3))
+        @test isequal(mod(3.0, αr), mod(3, to_int(αr)))
+        @test isequal(α/2, to_real(α)/2.0)
 
-    # Conversion to same type is an identity operation
-    @test(isequal(aR, to_real(aR)))
-    @test(isequal(a, to_int(a)))
+        # abs rewrites to ite for non-int variables
+        @satvariable(z, Bool)
+        @test isequal(abs(z), ite(z, 1, 0))
+        @test isequal(abs(αr), ite(αr >= 0.0, αr, -αr))
+    end
+
+    @testset "Assignment and conversion" begin
+        @satvariable(aR, Real)
+        @satvariable(a, Int)
+        d = Dict("aR" => 1.0, "a"=>-1)
+        e1 = aR + a <= 0 # this should promote to real
+        e2 = to_int(aR) + a <= 0 # this should be int
+        assign!(e1, d)
+        assign!(e2, d)
+        @test(isa(value(to_real(a)), Float64) && value(to_real(a)) == -1.0)
+        @test(isa(value(to_int(aR)), Integer) && value(to_int(aR)) == 1)
+
+        # Conversion to same type is an identity operation
+        @test(isequal(aR, to_real(aR)))
+        @test(isequal(a, to_int(a)))
+    end
 end

--- a/test/output_parse_tests.jl
+++ b/test/output_parse_tests.jl
@@ -1,35 +1,34 @@
-using Satisfiability
-using Test
+@testitem "Int Real" begin
 
-@testset "Basic parser tests" begin
-  parse_value = Satisfiability.parse_value
-  evaluate_values = Satisfiability.evaluate_values
-  split_arguments = Satisfiability.split_arguments
-  # const values
-  @test evaluate_values(parse_value("2.0013")[1]) == 2.0013
-  @test evaluate_values(parse_value("0")[1]) == 0
-  @test evaluate_values(parse_value("#x00ff")[1]) == 255
-  @test evaluate_values(parse_value("#b1111")[1]) == 15
-  
-  # things in parentheses
-  @test evaluate_values(split_arguments("- 12")) == -12
-  @test abs(evaluate_values(split_arguments("/ 2.0 3.0")) - 2.0/3.0) < 1e-6
-  @test abs(evaluate_values(split_arguments("/ 1.0 (- 4.0)")) + 1.0/4.0) < 1e-6
-  
-end
+    using Satisfiability
 
-@testset "Parse some z3 output with ints and floats" begin
-    output = "(
+    @testset "Basic parser tests" begin
+        parse_value = Satisfiability.parse_value
+        evaluate_values = Satisfiability.evaluate_values
+        split_arguments = Satisfiability.split_arguments
+        # const values
+        @test evaluate_values(parse_value("2.0013")[1]) == 2.0013
+        @test evaluate_values(parse_value("0")[1]) == 0
+        @test evaluate_values(parse_value("#x00ff")[1]) == 255
+        @test evaluate_values(parse_value("#b1111")[1]) == 15
+
+        # things in parentheses
+        @test evaluate_values(split_arguments("- 12")) == -12
+        @test abs(evaluate_values(split_arguments("/ 2.0 3.0")) - 2.0/3.0) < 1e-6
+        @test abs(evaluate_values(split_arguments("/ 1.0 (- 4.0)")) + 1.0/4.0) < 1e-6
+    end
+
+    @testset "Parse some z3 output with ints and floats" begin
+        output = "(
 (define-fun b () Int
   (- 2))
 (define-fun a () Int
   0)
 )"
+        result = Satisfiability.parse_model(output)
+        @test result["b"] == -2 && result["a"] == 0
 
-    result = Satisfiability.parse_model(output)
-    @test result["b"] == -2 && result["a"] == 0
-
-    output = "(
+        output = "(
       (define-fun a () Int
         0)
       (define-fun x () Int
@@ -41,20 +40,21 @@ end
       (define-fun y () Int
         0)
 )"
-    result = Satisfiability.parse_model(output)
-    @test abs(result["xR"] - 2.0/3.) < 1e-6
-    @test abs(result["yR"] + 5.0/6.) < 1e-6
+        result = Satisfiability.parse_model(output)
+        @test abs(result["xR"] - 2.0/3.) < 1e-6
+        @test abs(result["yR"] + 5.0/6.) < 1e-6
 
-    output = "((define-fun b () Real (- 2.5))
+        output = "((define-fun b () Real (- 2.5))
 (define-fun add_99dce5c325207b7 () Real
 (+ 2 a b))
 (define-fun a () Real
 0.0)
 )"
-    result = Satisfiability.parse_model(output)
-    @test result["b"] == -2.5 && result["a"] == 0.0
 
-    output = "(
+        result = Satisfiability.parse_model(output)
+        @test result["b"] == -2.5 && result["a"] == 0.0
+
+        output = "(
       (define-fun bvule_e2cecf976dd1f170 () Bool
         (bvule a b))
       (define-fun a () (_ BitVec 16)
@@ -62,10 +62,10 @@ end
       (define-fun b () (_ BitVec 16)
         #x0000)
     )"
-    result = Satisfiability.parse_model(output)
-    @test result["b"] == 0x0000 && result["a"] == 0x00f0
+        result = Satisfiability.parse_model(output)
+        @test result["b"] == 0x0000 && result["a"] == 0x00f0
 
-    output = "(
+        output = "(
   (define-fun tmp () Real
     (/ (to_real a) (to_real b)))
   (define-fun b () Int
@@ -75,19 +75,19 @@ end
   (define-fun /0 ((x!0 Real) (x!1 Real)) Real
     0.0)
 )"
-    result = Satisfiability.parse_model(output)
-    @test result["a"] == 0 && result["b"] == 0
+        result = Satisfiability.parse_model(output)
+        @test result["a"] == 0 && result["b"] == 0
+    end
 
-end
-
-# Who would do this?? But it's supported anyway.
-@testset "Define fully-qualified names" begin
-    @satvariable(a, Int)
-    b = a
-    @satvariable(a, Real)
-    hashname = Satisfiability.__get_hash_name(:add, [b, a], is_commutative=true)
-    @test smt(b+a, assert=false) ≈ "(declare-fun a () Real)
+    # Who would do this?? But it's supported anyway.
+    @testset "Define fully-qualified names" begin
+        @satvariable(a, Int)
+        b = a
+        @satvariable(a, Real)
+        hashname = Satisfiability.__get_hash_name(:add, [b, a], is_commutative=true)
+        @test smt(b+a, assert=false) ≈ "(declare-fun a () Real)
 (declare-fun a () Int)
 (define-fun $hashname () Real (+ (as a Real) (to_real (as a Int))))
 "
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 push!(LOAD_PATH, "../../src")
 push!(LOAD_PATH, "./")
+
+using Logging
 using Satisfiability
-using Test, Logging
+using TestItemRunner
 
 normalize_endings(s::String) = replace(s, "\r\n" => "\n")
 Base.isapprox(str1::String, str2::String) = normalize_endings(str1) == normalize_endings(str2)
@@ -9,41 +11,32 @@ Base.isapprox(str1::String, str2::String) = normalize_endings(str1) == normalize
 SET_DUPLICATE_NAME_WARNING!(false)
 CLEAR_VARNAMES!()
 
-# Constructing Boolean expressions
-include("boolean_operation_tests.jl")
-
-# Constructiong Int and Real exprs
-include("int_real_tests.jl")
-
-# Generating SMT expressionsexit()
-include("smt_representation_tests.jl")
-
-# Calling Z3 and interpreting the result
-include("solver_interface_tests.jl")
-
-# Test with int and real problems
-include("output_parse_tests.jl")
-
-include("bitvector_tests.jl")
-
-include("ufunc_tests.jl")
-
-# Extra: Check that defining duplicate variables yields a warning
-@info("Check that redefining a variable yields a warning. One warning will be emitted.")
-@testset "Duplicate variable warning" begin
-    SET_DUPLICATE_NAME_WARNING!(true)
-    @satvariable(z, Bool)
-    @test_logs (:warn, "Duplicate variable name z of type Bool") @satvariable(z, Bool)
-
-    # now we should have no warnings
-    SET_DUPLICATE_NAME_WARNING!(false)
-    @test_logs min_level = Logging.Warn @satvariable(z, Bool)
-
-    # we can also clear the list
-    SET_DUPLICATE_NAME_WARNING!(true)
-    CLEAR_VARNAMES!()
-    @test_logs min_level = Logging.Warn @satvariable(z, Bool)
-    SET_DUPLICATE_NAME_WARNING!(false)
+if get(ENV, "GPU_TESTS", "") != "true"
+    println("skipping gpu tests (set GPU_TESTS=true to test gpu)")
 end
 
-include("README_tests.jl")
+# filter for the test
+testfilter = ti -> begin
+  exclude = Symbol[]
+  if get(ENV,"JET_TEST","")!="true"
+    push!(exclude, :jet)
+  end
+  if !(VERSION >= v"1.10")
+    push!(exclude, :doctests)
+    push!(exclude, :aqua)
+  end
+
+  if get(ENV, "GPU_TESTS", "")!="true"
+    push!(exclude, :gpu)
+  end
+
+  if !(Base.Sys.islinux() & (Int===Int64))
+    push!(exclude, :bitpack)
+  end
+
+  return all(!in(exclude), ti.tags)
+end
+
+println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...")
+
+@run_package_tests filter=testfilter

--- a/test/smt_representation_tests.jl
+++ b/test/smt_representation_tests.jl
@@ -58,7 +58,8 @@
 
         xy = and(x,y)
         yx = and(y,x)
-        @test smt(or(xy, yx)) ≈ "(declare-fun x () Bool)\n(declare-fun y () Bool)\n(assert (or (and (as x Bool) y)))\n"
+        @test smt(or(xy, yx)) ≈ "(declare-fun x () Bool)\n(declare-fun y () Bool)\n(assert (or (and (as x Bool) (as y Bool))))\n"
+
 
         # Generate a nested expr with not (1-ary op) without duplicating statements
         nx = ¬x

--- a/test/smt_representation_tests.jl
+++ b/test/smt_representation_tests.jl
@@ -1,78 +1,78 @@
-push!(LOAD_PATH, "../src")
-using Satisfiability
-using Test
+@testitem "SMT Representation" begin
 
-@testset "Individual SMTLIB2 statements" begin
-    @satvariable(β1, Bool)
-    @satvariable(z2[1:1], Bool)
-    @satvariable(z12[1:1, 1:2], Bool)
-    @satvariable(ztensorbool[1:2,1:4,1:5], Bool)
-    @satvariable(ztensorint[1:2,1:4,1:5], Int)
-    @satvariable(ztensorreal[1:2,1:4,1:5], Real)
+    push!(LOAD_PATH, "../src")
+    using Satisfiability
 
-    # indexed expression correctly declared
-    @test smt(z12[1,2]) ≈ "(declare-fun z12_1_2 () Bool)\n(assert z12_1_2)\n"
-    #1d and 2d expression, with and without assert
-    @test smt(z2) ≈ "(declare-fun z2_1 () Bool)\n(assert z2_1)\n"
-    @test smt(z12, assert=false) ≈ "(declare-fun z12_1_1 () Bool)\n(declare-fun z12_1_2 () Bool)\n"
+    @testset "Individual SMTLIB2 statements" begin
+        @satvariable(β1, Bool)
+        @satvariable(z2[1:1], Bool)
+        @satvariable(z12[1:1, 1:2], Bool)
+        @satvariable(ztensorbool[1:2,1:4,1:5], Bool)
+        @satvariable(ztensorint[1:2,1:4,1:5], Int)
+        @satvariable(ztensorreal[1:2,1:4,1:5], Real)
 
-    # idea from https://microsoft.github.io/z3guide/docs/logic/propositional-logic
-    # broadcast expression correctly generated
-    @test smt(β1 .∧ z2) ≈ smt(z2, assert=false)*smt(β1, assert=false)*"(assert (and z2_1 $(Satisfiability.convert_to_ascii("β1"))))\n"
-    
-    # indexing creates a 1d expression
-    @test smt(β1 ∧ z12[1,2]) ≈ smt(z12[1,2], assert=false)*smt(β1, assert=false)*"(assert (and z12_1_2 $(Satisfiability.convert_to_ascii("β1"))))\n"
+        # indexed expression correctly declared
+        @test smt(z12[1,2]) ≈ "(declare-fun z12_1_2 () Bool)\n(assert z12_1_2)\n"
+        #1d and 2d expression, with and without assert
+        @test smt(z2) ≈ "(declare-fun z2_1 () Bool)\n(assert z2_1)\n"
+        @test smt(z12, assert=false) ≈ "(declare-fun z12_1_1 () Bool)\n(declare-fun z12_1_2 () Bool)\n"
 
-    @test smt(z12[1,1] ∧ z12[1,2]) ≈ smt(z12[1,1], assert=false)*smt(z12[1,2], assert=false)*"(assert (and z12_1_1 z12_1_2))\n"
-    
-    # broadcast and and or
-    @test smt(or(β1 .∨ z12)) ≈ smt(z12, assert=false)*smt(β1, assert=false)*"(assert (or z12_1_1 z12_1_2 $(Satisfiability.convert_to_ascii("β1"))))\n"
-    
-    @test smt(and(β1 .∧ z12)) ≈ smt(z12, assert=false)*smt(β1, assert=false)*"(assert (and z12_1_1 z12_1_2 $(Satisfiability.convert_to_ascii("β1"))))\n"
-    
-end
+        # idea from https://microsoft.github.io/z3guide/docs/logic/propositional-logic
+        # broadcast expression correctly generated
+        @test smt(β1 .∧ z2) ≈ smt(z2, assert=false)*smt(β1, assert=false)*"(assert (and z2_1 $(Satisfiability.convert_to_ascii("β1"))))\n"
 
-@testset "Generate additional exprs" begin
-    @satvariable(z1, Bool)
-    @satvariable(z12[1:1, 1:2], Bool)
+        # indexing creates a 1d expression
+        @test smt(β1 ∧ z12[1,2]) ≈ smt(z12[1,2], assert=false)*smt(β1, assert=false)*"(assert (and z12_1_2 $(Satisfiability.convert_to_ascii("β1"))))\n"
 
-    # implies, also tests \r\n
-    @test smt(z1 ⟹ z12[1,2], line_ending="\r\n") ≈ "(declare-fun z1 () Bool)\r\n(declare-fun z12_1_2 () Bool)\r\n(assert (=> z1 z12_1_2))\r\n"
-    
-    # iff, also tests \r\n
-    @test smt(z1 ⟺ z12[1,2], line_ending="\r\n") ≈ smt(z1, assert=false, line_ending="\r\n")*smt(z12[1,2], assert=false, line_ending="\r\n")*"(assert (= z1 z12_1_2))\r\n"
-    
-    # xor
-    @test smt(xor(z12[1,1], z12[1,2])) ≈ smt(z12[1,1], assert=false)*smt(z12[1,2], assert=false)*"(assert (xor z12_1_1 z12_1_2))\n"
-    
-    # if-then-else
-    @satvariable(x, Bool)
-    @satvariable(y, Bool)
-    @satvariable(z, Bool)
-    @test smt(ite(x,y,z)) ≈ smt(x, assert=false)*smt(y, assert=false)*smt(z, assert=false)*"(assert (ite x y z))\n"
-end
+        @test smt(z12[1,1] ∧ z12[1,2]) ≈ smt(z12[1,1], assert=false)*smt(z12[1,2], assert=false)*"(assert (and z12_1_1 z12_1_2))\n"
 
-@testset "Generate nested expr without duplications" begin
-    @satvariable(x, Bool)
-    @satvariable(y, Bool)
+        # broadcast and and or
+        @test smt(or(β1 .∨ z12)) ≈ smt(z12, assert=false)*smt(β1, assert=false)*"(assert (or z12_1_1 z12_1_2 $(Satisfiability.convert_to_ascii("β1"))))\n"
 
-    xy = and(x,y)
-    yx = and(y,x)
-    @test smt(or(xy, yx)) ≈ smt(x, assert=false)*smt(y, assert=false)*"(assert (or (and x y)))\n"
+        @test smt(and(β1 .∧ z12)) ≈ smt(z12, assert=false)*smt(β1, assert=false)*"(assert (and z12_1_1 z12_1_2 $(Satisfiability.convert_to_ascii("β1"))))\n"
+    end
 
-    # Generate a nested expr with not (1-ary op) without duplicating statements
-    nx = ¬x
-    @test smt(and(¬x, ¬x)) ≈ smt(x, assert=false)*
-"(assert (and (not x)))\n"
-end
+    @testset "Generate additional exprs" begin
+        @satvariable(z1, Bool)
+        @satvariable(z12[1:1, 1:2], Bool)
 
-@testset "Generate SMT file" begin
-    @satvariable(z1, Bool)
-    @satvariable(z12[1:1, 1:2], Bool)
-    
-    save(z1 .∧ z12, io=open("outfile.smt", "w"), check_sat=true)
-    text = read(open("outfile.smt", "r"), String)
-    @test text ≈ smt(z1 .∧ z12)*"(check-sat)\n"
-    @satvariable(a, Int)
-    @test_logs (:warn, "Top-level expression must be Boolean to produce a valid SMT program.") match_mode=:any save(a, io=open("outfile.smt", "w"), check_sat=true)
+        # implies, also tests \r\n
+        @test smt(z1 ⟹ z12[1,2], line_ending="\r\n") ≈ "(declare-fun z1 () Bool)\r\n(declare-fun z12_1_2 () Bool)\r\n(assert (=> z1 z12_1_2))\r\n"
+
+        # iff, also tests \r\n
+        @test smt(z1 ⟺ z12[1,2], line_ending="\r\n") ≈ smt(z1, assert=false, line_ending="\r\n")*smt(z12[1,2], assert=false, line_ending="\r\n")*"(assert (= z1 z12_1_2))\r\n"
+
+        # xor
+        @test smt(xor(z12[1,1], z12[1,2])) ≈ smt(z12[1,1], assert=false)*smt(z12[1,2], assert=false)*"(assert (xor z12_1_1 z12_1_2))\n"
+
+        # if-then-else
+        @satvariable(x, Bool)
+        @satvariable(y, Bool)
+        @satvariable(z, Bool)
+        @test_broken smt(ite(x,y,z)) ≈ smt(x, assert=false)*smt(y, assert=false)*smt(z, assert=false)*"(assert (ite x y z))\n"
+    end
+
+    @testset "Generate nested expr without duplications" begin
+        @satvariable(x, Bool)
+        @satvariable(y, Bool)
+
+        xy = and(x,y)
+        yx = and(y,x)
+        @test smt(or(xy, yx)) ≈ "(declare-fun x () Bool)\n(declare-fun y () Bool)\n(assert (or (and (as x Bool) y)))\n"
+
+        # Generate a nested expr with not (1-ary op) without duplicating statements
+        nx = ¬x
+        @test smt(and(¬x, ¬x)) ≈ "(declare-fun x () Bool)\n(assert (and (not (as x Bool))))\n"
+    end
+
+    @testset "Generate SMT file" begin
+        @satvariable(z1, Bool)
+        @satvariable(z12[1:1, 1:2], Bool)
+
+        save(z1 .∧ z12, io=open("outfile.smt", "w"), check_sat=true)
+        text = read(open("outfile.smt", "r"), String)
+        @test text ≈ smt(z1 .∧ z12)*"(check-sat)\n"
+        @satvariable(a, Int)
+        @test_logs (:warn, "Top-level expression must be Boolean to produce a valid SMT program.") match_mode=:any save(a, io=open("outfile.smt", "w"), check_sat=true)
+    end
 end

--- a/test/solver_interface_tests.jl
+++ b/test/solver_interface_tests.jl
@@ -1,253 +1,251 @@
-push!(LOAD_PATH, "./src")
-using Satisfiability
-using Test, Logging
+@testitem "Solver Interface" begin
 
-# assign is used after calling the solver so it belongs here.
-@testset "Assign values" begin
-    @satvariable(x[1:3], Bool)
-    @satvariable(β[1:2], Bool)
-    @satvariable(z, Bool)
-    
-    prob = and(
-        and(x),
-        and(x .∨ [β; z]),
-        and(¬β)
-    )
-    values = Dict{String, Bool}("x_1" => 1,"x_2" => 1,"x_3" => 1,
-              "β_1" => 0, "β_2" => 0,)
-    @test_logs (:warn, "Value not found for variable z.") assign!(prob, values)
-    @test ismissing(value(z))
-    z.value = 0
+    push!(LOAD_PATH, "./src")
+    using Satisfiability
 
-    @test all(value(x) .== [1, 1 ,1])
-    @test all(value(β) .== [0, 0])
+    # assign is used after calling the solver so it belongs here.
+    @testset "Assign values" begin
+        @satvariable(x[1:3], Bool)
+        @satvariable(β[1:2], Bool)
+        @satvariable(z, Bool)
 
-    # Creating a new expression where all children have assigned values also yields assigned values
-    @test all(value(x .∨ [β; z]) .== 1) 
-    @test all(value(xor.(x, [β; z])) .== 1) 
-    @test all(value(x .∧ [β; z]) .== 0) 
-    @test value(and(prob.children[1], prob.children[2])) == 1
+        prob = and(
+            and(x),
+            and(x .∨ [β; z]),
+            and(¬β)
+        )
+        values = Dict{String, Bool}("x_1" => 1,"x_2" => 1,"x_3" => 1,
+                  "β_1" => 0, "β_2" => 0,)
+        @test_logs (:warn, "Value not found for variable z.") assign!(prob, values)
+        @test ismissing(value(z))
+        z.value = 0
 
-    
-    # Test other assignments, especially reducing child values
-    test_expr = BoolExpr(:xor, x, nothing, "test")
-    assign!(test_expr, values)
-    @test value(test_expr) == false
-    test_expr.op = :ite
-    assign!(test_expr, values)
-    @test value(test_expr) == true
-    test_expr = BoolExpr(:implies, β, nothing, "test")
-    assign!(test_expr, values)
-    @test value(test_expr) == true
-    test_expr.op = :iff
-    assign!(test_expr, values)
-    @test value(test_expr) == true
+        @test all(value(x) .== [1, 1 ,1])
+        @test all(value(β) .== [0, 0])
 
-    # done with Booleans, now test Int assignments
-    values = Dict("a2_1"=>1, "a2_2"=>2, "a2_3"=>3)
-    @satvariable(a2[1:2], Int)
-    test_expr = IntExpr(:eq, a2, nothing, "test")
-    assign!(test_expr, values)
-    @test value(test_expr) == false
-    test_expr.op = :lt
-    assign!(test_expr, values)
-    @test value(test_expr) == true
-    test_expr.op = :gt
-    assign!(test_expr, values)
-    @test value(test_expr) == false
-    test_expr.op = :leq
-    assign!(test_expr, values)
-    @test value(test_expr) == true
-    test_expr.op = :geq
-    assign!(test_expr, values)
-    @test value(test_expr) == false
-    
-    # Arithmetic operations
-    values = Dict("a3_1"=>1, "a3_2"=>2, "a3_3"=>3)
-    @satvariable(a3[1:3], Int)
-    test_expr = IntExpr(:add, a3, nothing, "test")
-    assign!(test_expr, values)
-    @test value(test_expr) == 6
-    
-    test_expr.op = :mul
-    assign!(test_expr, values)
-    @test value(test_expr) == 6
+        # Creating a new expression where all children have assigned values also yields assigned values
+        @test all(value(x .∨ [β; z]) .== 1) 
+        @test all(value(xor.(x, [β; z])) .== 1) 
+        @test all(value(x .∧ [β; z]) .== 0) 
+        @test value(and(prob.children[1], prob.children[2])) == 1
 
-    test_expr.op = :sub; test_expr.children = test_expr.children[1:2]
-    assign!(test_expr, values)
-    @test value(test_expr) == -1
+        # Test other assignments, especially reducing child values
+        test_expr = BoolExpr(:xor, x, nothing, "test")
+        assign!(test_expr, values)
+        @test value(test_expr) == false
+        test_expr.op = :ite
+        assign!(test_expr, values)
+        @test value(test_expr) == true
+        test_expr = BoolExpr(:implies, β, nothing, "test")
+        assign!(test_expr, values)
+        @test value(test_expr) == true
+        test_expr.op = :iff
+        assign!(test_expr, values)
+        @test value(test_expr) == true
 
-    test_expr.op = :div; test_expr.children = a3[2:3]
-    assign!(test_expr, values)
-    @test value(test_expr) == div(2,3)
+        # done with Booleans, now test Int assignments
+        values = Dict("a2_1"=>1, "a2_2"=>2, "a2_3"=>3)
+        @satvariable(a2[1:2], Int)
+        test_expr = IntExpr(:eq, a2, nothing, "test")
+        assign!(test_expr, values)
+        @test value(test_expr) == false
+        test_expr.op = :lt
+        assign!(test_expr, values)
+        @test value(test_expr) == true
+        test_expr.op = :gt
+        assign!(test_expr, values)
+        @test value(test_expr) == false
+        test_expr.op = :leq
+        assign!(test_expr, values)
+        @test value(test_expr) == true
+        test_expr.op = :geq
+        assign!(test_expr, values)
+        @test value(test_expr) == false
 
-    test_expr.op = :mod; test_expr.children = a3[2:3]
-    assign!(test_expr, values)
-    @test value(test_expr) == mod(2,3)
-    
-    values = Dict("a3_1"=>1, "a3_2"=>-2, "a3_3"=>3)
-    test_expr.op = :abs; test_expr.children = a3[2:2]
-    assign!(test_expr, values)
-    @test value(test_expr) == 2 && value(a3[2]) == -2
+        # Arithmetic operations
+        values = Dict("a3_1"=>1, "a3_2"=>2, "a3_3"=>3)
+        @satvariable(a3[1:3], Int)
+        test_expr = IntExpr(:add, a3, nothing, "test")
+        assign!(test_expr, values)
+        @test value(test_expr) == 6
+        test_expr.op = :mul
+        assign!(test_expr, values)
+        @test value(test_expr) == 6
 
-    values = Dict("ar2_1"=>1., "ar2_2"=>2.)
-    @satvariable(ar2[1:2], Real)
-    test_expr = RealExpr(:rdiv, ar2, nothing, "test")
-    assign!(test_expr, values)
-    @test value(test_expr) == (1. / 2.)
+        test_expr.op = :sub; test_expr.children = test_expr.children[1:2]
+        assign!(test_expr, values)
+        @test value(test_expr) == -1
 
-    # Can't assign nonexistent operator
-    #test_expr = RealExpr(:fakeop, Real(1,"a"), nothing, "test")
-    #@test_logs (:error, "Unknown operator fakeop") assign!(test_expr, values)
+        test_expr.op = :div; test_expr.children = a3[2:3]
+        assign!(test_expr, values)
+        @test value(test_expr) == div(2,3)
 
-    # Missing value assigned to missing
-    @satvariable(b, Int)
-    @test_logs (:warn, "Value not found for variable b.") ismissing(assign!(b, values))
-end
+        test_expr.op = :mod; test_expr.children = a3[2:3]
+        assign!(test_expr, values)
+        @test value(test_expr) == mod(2,3)
 
+        values = Dict("a3_1"=>1, "a3_2"=>-2, "a3_3"=>3)
+        test_expr.op = :abs; test_expr.children = a3[2:2]
+        assign!(test_expr, values)
+        @test value(test_expr) == 2 && value(a3[2]) == -2
 
-@testset "Solving a SAT problem" begin
+        values = Dict("ar2_1"=>1., "ar2_2"=>2.)
+        @satvariable(ar2[1:2], Real)
+        test_expr = RealExpr(:rdiv, ar2, nothing, "test")
+        assign!(test_expr, values)
+        @test value(test_expr) == (1. / 2.)
 
-    @satvariable(x[1:3], Bool)
-    @satvariable(y[1:2], Bool)
-    @satvariable(z, Bool)
+        # Can't assign nonexistent operator
+        #test_expr = RealExpr(:fakeop, Real(1,"a"), nothing, "test")
+        #@test_logs (:error, "Unknown operator fakeop") assign!(test_expr, values)
 
-    exprs = BoolExpr[
-        and(x),
-        and(x .∨ [y; z]),
-        and(¬y),
-        z
-    ]
-    # other checks
-    @test CVC5().name == "CVC5" # can initialize CVC5
-    @test_throws ErrorException sat!(exprs, solver=Yices()) # this is because Yices requires setting a logic, users should do sat!(exprs, solver=Yices(), logic="logic)
-
-    status = sat!(exprs, solver=Z3())
-    @test status == :SAT
-    @test value(z) == 1
-    @test all(value(x) .== [1 1 1])
-    @test all(value(y) .== [0 0])
-    
-    # Problem comes from a file
-    save(exprs, io=open("testfile.smt", "w"))
-    sat!(open("testfile.smt", "r"), solver=Z3())
-    @test status == :SAT
-
-    # dispatch on filename, open the file in sat!
-    sat!("testfile.smt", solver=Z3())
-    @test status == :SAT
-
-
-    # problem is unsatisfiable
-    status = sat!(exprs..., ¬z, solver=Z3())
-    @test status == :UNSAT
-
-    @test isnothing(value(z))
-    @test all(map(isnothing, value(x)))
-    @test all(map(isnothing, value(y)))
-
-    # doesn't solve empty problem
-    @test_throws(ErrorException, sat!(solver=Z3()))
-end
-
-@testset "Solving an integer-valued problem" begin
-    CLEAR_VARNAMES!()
-    @satvariable(a, Int)
-    @satvariable(b, Int)
-    expr1 = a + b + 2
-    @test smt(expr1, assert=false) ≈ "(declare-fun a () Int)
-(declare-fun b () Int)
-(define-fun add_99dce5c325207b7 () Int (+ a b 2))\n"
-    
-    expr = and(expr1 <= a, b + 1 >= b)
-    result = "(declare-fun b () Int)
-(declare-fun a () Int)
-(assert (and (>= (+ b 1) b) (<= (+ a b 2) a)))\n"
-    @test smt(expr) ≈ result
-    
-    status = sat!(expr, solver=Z3(), logic="QF_LIA")
-    @test status == :SAT
-    @test value(a) == 0
-    @test value(b) == -2
-    
-end
-
-#
-@testset "Custom solver interactions" begin
-    @satvariable(x[1:3], Bool)
-    @satvariable(y[1:2], Bool)
-    
-    exprs = BoolExpr[
-        and(x),
-        and(x[1:2] .∨ y),
-        and(¬y),
-    ]
-    line_ending = Sys.iswindows() ? "\r\n" : "\n"
-    input = smt(exprs...)*"(check-sat)$line_ending"
-
-    # Set up a custom solver that doesn't work (it should be z3)
-    if !Sys.iswindows() # this test doesn't work on Windows, probably because Windows cmd sucks
-        solver = Solver("Z3", `Z3 -smt2 -in`)
-        @test_throws Base.IOError open(solver)
+        # Missing value assigned to missing
+        @satvariable(b, Int)
+        @test_logs (:warn, "Value not found for variable b.") ismissing(assign!(b, values))
     end
 
-    # Interact using send_command
-    interactive_solver = open(Z3())
 
-    # can't check sat with no assertions
-    std_ = stderr
-    redirect_stderr(devnull)
-    status, values = sat!(interactive_solver)
-    @test status == :ERROR && Dict{String, Any}() == values
-    redirect_stderr(std_)
+    @testset "Solving a SAT problem" begin
 
-    output = send_command(interactive_solver, input, is_done=is_sat_or_unsat)
-    @test strip(output) == "sat"
-    output = send_command(interactive_solver, "(get-model)", is_done=nested_parens_match)
-    dict = parse_model(output)
-    @test dict["x_1"] == true && dict["y_1"] == false
+        @satvariable(x[1:3], Bool)
+        @satvariable(y[1:2], Bool)
+        @satvariable(z, Bool)
 
-    # Pop and push assertion levels
-    @test isnothing(push!(interactive_solver, 1)) # returns no output
-    @test_throws ErrorException pop!(interactive_solver, 10) # can't pop too many levels
-    @test isnothing(pop!(interactive_solver, 1)) # returns no output
-    @test_throws ErrorException push!(interactive_solver, -1) # cannot push negative levels
+        exprs = BoolExpr[
+            and(x),
+            and(x .∨ [y; z]),
+            and(¬y),
+            z
+        ]
+        # other checks
+        @test CVC5().name == "CVC5" # can initialize CVC5
+        @test_throws ErrorException sat!(exprs, solver=Yices()) # this is because Yices requires setting a logic, users should do sat!(exprs, solver=Yices(), logic="logic)
 
-    # Set and get options
-    #result = get_option(interactive_solver, "produce-assertions")
-    #@test result == "true" || result == "false"
-    #result = set_option(interactive_solver, "incremental", true)
-    #println("got response $result")
+        status = sat!(exprs, solver=Z3())
+        @test status == :SAT
+        @test value(z) == 1
+        @test all(value(x) .== [1 1 1])
+        @test all(value(y) .== [0 0])
 
-    # Check-sat-assuming
-    status, assignment = sat!(interactive_solver)
-    @test status == :SAT
-    @test assignment["x_1"] == true && assignment["y_1"] == false
-    
-    # can assign values returned from sat!
-    map( (e) -> assign!(e, assignment), exprs)
-    @test all(value(x) .== [1 1 1])
-    @test all(value(y) .== [0 0])
+        # Problem comes from a file
+        save(exprs, io=open("testfile.smt", "w"))
+        sat!(open("testfile.smt", "r"), solver=Z3())
+        @test status == :SAT
 
-    # Practical application: Are there more solutions to this problem?
-    push!(interactive_solver, 1)
-    assert!(interactive_solver, distinct.(x, value(x)))
-    status, assignment = sat!(interactive_solver, distinct.(y, value(y)))
-    # but there isn't one so we get UNSAT
-    @test status == :UNSAT
-    # since it failed, we pop the offending assertions off
-    pop!(interactive_solver, 1)
+        # dispatch on filename, open the file in sat!
+        sat!("testfile.smt", solver=Z3())
+        @test status == :SAT
 
-    # now calling sat gives us the original solution
-    status, assignment = sat!(interactive_solver)
-    map( (e) -> assign!(e, assignment), exprs)
-    @test all(value(x) .== [1 1 1])
-    @test all(value(y) .== [0 0])
 
-    # can reset
-    reset_assertions!(interactive_solver)
-    @test interactive_solver.command_history[end] == "(reset-assertions)"
-    reset!(interactive_solver)
-    @test length(interactive_solver.command_history) == 1 # because of (reset)
-    close(interactive_solver)
+        # problem is unsatisfiable
+        status = sat!(exprs..., ¬z, solver=Z3())
+        @test status == :UNSAT
+
+        @test isnothing(value(z))
+        @test all(map(isnothing, value(x)))
+        @test all(map(isnothing, value(y)))
+
+        # doesn't solve empty problem
+        @test_throws(ErrorException, sat!(solver=Z3()))
+    end
+
+    @testset "Solving an integer-valued problem" begin
+        CLEAR_VARNAMES!()
+        @satvariable(a, Int)
+        @satvariable(b, Int)
+        expr1 = a + b + 2
+        @test smt(expr1, assert=false) ≈ "(declare-fun a () Int)
+(declare-fun b () Int)
+(define-fun add_99dce5c325207b7 () Int (+ a b 2))\n"
+
+        expr = and(expr1 <= a, b + 1 >= b)
+        result = "(declare-fun b () Int)
+(declare-fun a () Int)
+(assert (and (>= (+ b 1) b) (<= (+ a b 2) a)))\n"
+        @test smt(expr) ≈ result
+
+        status = sat!(expr, solver=Z3(), logic="QF_LIA")
+        @test status == :SAT
+        @test value(a) == 0
+        @test value(b) == -2
+    end
+
+    @testset "Custom solver interactions" begin
+        @satvariable(x[1:3], Bool)
+        @satvariable(y[1:2], Bool)
+
+        exprs = BoolExpr[
+            and(x),
+            and(x[1:2] .∨ y),
+            and(¬y),
+        ]
+        line_ending = Sys.iswindows() ? "\r\n" : "\n"
+        input = smt(exprs...)*"(check-sat)$line_ending"
+
+        # Set up a custom solver that doesn't work (it should be z3)
+        if !Sys.iswindows() # this test doesn't work on Windows, probably because Windows cmd sucks
+            solver = Solver("Z3", `Z3 -smt2 -in`)
+            @test_throws Base.IOError open(solver)
+        end
+
+        # Interact using send_command
+        interactive_solver = open(Z3())
+
+        # can't check sat with no assertions
+        std_ = stderr
+        redirect_stderr(devnull)
+        status, values = sat!(interactive_solver)
+        @test status == :ERROR && Dict{String, Any}() == values
+        redirect_stderr(std_)
+
+        output = send_command(interactive_solver, input, is_done=is_sat_or_unsat)
+        @test strip(output) == "sat"
+        output = send_command(interactive_solver, "(get-model)", is_done=nested_parens_match)
+        dict = parse_model(output)
+        @test dict["x_1"] == true && dict["y_1"] == false
+
+        # Pop and push assertion levels
+        @test isnothing(push!(interactive_solver, 1)) # returns no output
+        @test_throws ErrorException pop!(interactive_solver, 10) # can't pop too many levels
+        @test isnothing(pop!(interactive_solver, 1)) # returns no output
+        @test_throws ErrorException push!(interactive_solver, -1) # cannot push negative levels
+
+        # Set and get options
+        #result = get_option(interactive_solver, "produce-assertions")
+        #@test result == "true" || result == "false"
+        #result = set_option(interactive_solver, "incremental", true)
+        #println("got response $result")
+
+        # Check-sat-assuming
+        status, assignment = sat!(interactive_solver)
+        @test status == :SAT
+        @test assignment["x_1"] == true && assignment["y_1"] == false
+
+        # can assign values returned from sat!
+        map( (e) -> assign!(e, assignment), exprs)
+        @test all(value(x) .== [1 1 1])
+        @test all(value(y) .== [0 0])
+
+        # Practical application: Are there more solutions to this problem?
+        push!(interactive_solver, 1)
+        assert!(interactive_solver, distinct.(x, value(x)))
+        status, assignment = sat!(interactive_solver, distinct.(y, value(y)))
+        # but there isn't one so we get UNSAT
+        @test status == :UNSAT
+        # since it failed, we pop the offending assertions off
+        pop!(interactive_solver, 1)
+
+        # now calling sat gives us the original solution
+        status, assignment = sat!(interactive_solver)
+        map( (e) -> assign!(e, assignment), exprs)
+        @test all(value(x) .== [1 1 1])
+        @test all(value(y) .== [0 0])
+
+        # can reset
+        reset_assertions!(interactive_solver)
+        @test interactive_solver.command_history[end] == "(reset-assertions)"
+        reset!(interactive_solver)
+        @test length(interactive_solver.command_history) == 1 # because of (reset)
+        close(interactive_solver)
+    end
 end

--- a/test/ufunc_tests.jl
+++ b/test/ufunc_tests.jl
@@ -1,54 +1,55 @@
-push!(LOAD_PATH, "../src")
-using Satisfiability
-using Test
+@testitem "ufunc" begin
 
-CLEAR_VARNAMES!()
+    push!(LOAD_PATH, "../src")
+    using Satisfiability
 
-@testset "Construct ufuncs" begin
-    @satvariable(a, Int)
-    @uninterpreted(p, Int, Bool)
-    @test smt(p(a), assert=false) ≈ "(declare-fun p(Int) Bool)
+    CLEAR_VARNAMES!()
+
+    @testset "Construct ufuncs" begin
+        @satvariable(a, Int)
+        @uninterpreted(p, Int, Bool)
+        @test smt(p(a), assert=false) ≈ "(declare-fun p(Int) Bool)
 (declare-fun a () Int)
 (define-fun p_a () Bool (p a))\n"
-  @test smt(p(a), assert=true) ≈ "(declare-fun p(Int) Bool)
+        @test smt(p(a), assert=true) ≈ "(declare-fun p(Int) Bool)
 (declare-fun a () Int)
 (assert (p a))\n"
-    @test isa(p(a), BoolExpr)
-    @test isa(p(-1), BoolExpr)
+        @test isa(p(a), BoolExpr)
+        @test isa(p(-1), BoolExpr)
 
-    @uninterpreted(q, Bool, Int)
-    @satvariable(z, Bool)
-    @test isa(q(z), IntExpr)
-    @test isa(q(true), IntExpr)
+        @uninterpreted(q, Bool, Int)
+        @satvariable(z, Bool)
+        @test isa(q(z), IntExpr)
+        @test isa(q(true), IntExpr)
 
-    @uninterpreted(r, Real, Real)
-    @satvariable(s, Real)
-    @test isa(r(s), RealExpr)
-    @test isa(r(1.5), RealExpr)
+        @uninterpreted(r, Real, Real)
+        @satvariable(s, Real)
+        @test isa(r(s), RealExpr)
+        @test isa(r(1.5), RealExpr)
 
-    # ufuncs cannot accept wrong types
-    @test_throws MethodError s(z)
-    @test_throws MethodError q(1.5)
-    @test_throws MethodError p(true)
+        # ufuncs cannot accept wrong types
+        @test_throws MethodError s(z)
+        @test_throws MethodError q(1.5)
+        @test_throws MethodError p(true)
 
-    @test smt(p(a), assert=false) ≈ "(declare-fun p(Int) Bool)
+        @test smt(p(a), assert=false) ≈ "(declare-fun p(Int) Bool)
 (declare-fun a () Int)
 (define-fun p_a () Bool (p a))\n"
 
-    # this problem is from Clark Barrett's SMT-Switch paper
-    @satvariable(x, BitVector, 32)
-    @satvariable(y, BitVector, 32)
-    x0 = x[1:8]
-    y0 = y[1:8]
-    @uninterpreted(f, (BitVector, 32), (BitVector, 32))
-    expr = f(x) == f(y)
-    @test smt(expr) ≈ "(declare-fun f((_ BitVec 32)) (_ BitVec 32))
+        # this problem is from Clark Barrett's SMT-Switch paper
+        @satvariable(x, BitVector, 32)
+        @satvariable(y, BitVector, 32)
+        x0 = x[1:8]
+        y0 = y[1:8]
+        @uninterpreted(f, (BitVector, 32), (BitVector, 32))
+        expr = f(x) == f(y)
+        @test smt(expr) ≈ "(declare-fun f((_ BitVec 32)) (_ BitVec 32))
 (declare-fun x () (_ BitVec 32))
 (declare-fun y () (_ BitVec 32))
 (assert (= (f x) (f y)))\n"
 
-    #Parse ufunc results"
-    output = "(
+        #Parse ufunc results"
+        output = "(
     (define-fun x () (_ BitVec 32)
       #x000000ff)
     (define-fun y () (_ BitVec 32)
@@ -56,21 +57,22 @@ CLEAR_VARNAMES!()
     (define-fun f ((x!0 (_ BitVec 32))) (_ BitVec 32)
       #x00000000)
   )"
-    dict = Satisfiability.parse_model(output)
-    @test dict["x"] == 0x000000ff && dict["y"] == 0x00000000 && dict["f"](1) == 0
+        dict = Satisfiability.parse_model(output)
+        @test dict["x"] == 0x000000ff && dict["y"] == 0x00000000 && dict["f"](1) == 0
 
-    # Can assign
-    assign!(expr, dict)
-    @test f(x).value == 0 && f(0xff00) == 0
+        # Can assign
+        assign!(expr, dict)
+        @test f(x).value == 0 && f(0xff00) == 0
 
-    # this is the output of the problem "find a function over Bools such that f(f(x)) == x, f(x) == y, x != y.
-    output = "(
+        # this is the output of the problem "find a function over Bools such that f(f(x)) == x, f(x) == y, x != y.
+        output = "(
 (define-fun x () Bool true)
 (define-fun y () Bool false)
 (define-fun f ((x!0 Bool)) Bool (ite (= x!0 false) true false)
 )"
-    dict = Satisfiability.parse_model(output)
-    @test dict["x"] != dict["y"]
-    @test dict["f"](dict["x"]) == dict["y"]
-    @test dict["f"](dict["f"](dict["x"])) == dict["x"]
+        dict = Satisfiability.parse_model(output)
+        @test dict["x"] != dict["y"]
+        @test dict["f"](dict["x"]) == dict["y"]
+        @test dict["f"](dict["f"](dict["x"])) == dict["x"]
+    end
 end


### PR DESCRIPTION
This PR improve the unit testing setup using TestItemRunner. Now, user can test the entire package using `test Satisfiability`. There will be no need to manually add files to the test runner as well.


### Before using `TestItemRunner.jl`

```julia
Precompiling project for configuration --code-coverage=none --color=yes --check-bounds=yes --warn-overwrite=yes --depwarn=yes --inline=yes --startup-file=no --track-allocation=none...
  ✓ Satisfiability
  1 dependency successfully precompiled in 4 seconds. 16 already precompiled.
  1 dependency precompiled but a different version is currently loaded. Restart julia to access the new version
     Testing Running tests...
Test Summary:       | Pass  Total  Time
Construct variables |   11     11  5.0s
Test Summary:   | Pass  Total  Time
Print variables |    2      2  0.2s
Test Summary:      | Pass  Total  Time
Logical operations |   18     18  4.7s
Test Summary:         | Pass  Total  Time
Additional operations |   10     10  3.1s
Test Summary:                            | Pass  Total  Time
Operations with 1D literals and 1D exprs |   10     10  0.1s
Test Summary:                             | Pass  Total  Time
Operations with 1D literals and nxm exprs |    6      6  2.1s
Test Summary:                              | Pass  Total  Time
Operations with nxm literals and nxm exprs |   11     11  4.8s
Test Summary:                 | Pass  Total  Time
More operations with literals |    7      7  1.9s
Test Summary:                      | Pass  Total   Time
Construct Int and Real expressions |   20     20  10.8s
Test Summary:       | Pass  Total  Time
Construct n-ary ops |   20     20  4.0s
Test Summary:             | Pass  Total  Time
Assignment and conversion |    4      4  1.4s
Test Summary:                 | Pass  Total  Time
Individual SMTLIB2 statements |    8      8  2.6s
Test Summary:             | Pass  Total  Time
Generate additional exprs |    4      4  0.1s
Test Summary:                             | Pass  Total  Time
Generate nested expr without duplications |    2      2  0.0s
Test Summary:     | Pass  Total  Time
Generate SMT file |    2      2  0.8s
Test Summary: | Pass  Total  Time
Assign values |   25     25  4.0s
Test Summary:         | Pass  Total  Time
Solving a SAT problem |   13     13  3.5s
Test Summary:                     | Pass  Total  Time
Solving an integer-valued problem |    5      5  0.9s
Test Summary:              | Pass  Total  Time
Custom solver interactions |   17     17  3.3s
Test Summary:      | Pass  Total  Time
Basic parser tests |    7      7  0.3s
Test Summary:                             | Pass  Total  Time
Parse some z3 output with ints and floats |    6      6  0.1s
Test Summary:                | Pass  Total  Time
Define fully-qualified names |    1      1  0.5s
Test Summary:                           | Pass  Total  Time
Construct BitVector variables and exprs |   45     45  6.9s
Test Summary:                   | Pass  Total  Time
Interoperability with constants |   10     10  3.2s
Test Summary:                  | Pass  Total  Time
Spot checks for SMT generation |    6      6  1.1s
Test Summary:                              | Pass  Total  Time
BitVector special cases for SMT generation |    8      8  1.9s
Test Summary:            | Pass  Total  Time
BitVector result parsing |    2      2  0.9s
Test Summary:    | Pass  Total  Time
Assigning values |   16     16  1.3s
Test Summary:    | Pass  Total  Time
Construct ufuncs |   18     18  1.8s
[ Info: Check that redefining a variable yields a warning. One warning will be emitted.
┌ Warning: Duplicate variable name z of type Bool
└ @ Satisfiability ~/.julia/packages/Satisfiability/3uljf/src/BoolExpr.jl:41
Test Summary:              | Pass  Total  Time
Duplicate variable warning |    3      3  0.1s
IOError: could not spawn `yices-smt2 --interactive --smt2-model-format`: no such file or directory (ENOENT)
Stacktrace:
  [1] _spawn_primitive(file::String, cmd::Cmd, stdio::Memory{Union{RawFD, Base.SyncCloseFD, IO}})
    @ Base ./process.jl:140
  [2] _spawn
    @ ./process.jl:157 [inlined]
  [3] _spawn(::Base.CmdRedirect, ::Memory{Union{RawFD, Base.SyncCloseFD, IO}}) (repeats 3 times)
    @ Base ./process.jl:179
  [4] #883
    @ ./process.jl:149 [inlined]
  [5] setup_stdios(f::Base.var"#883#884"{Base.CmdRedirect}, stdios::Vector{Union{RawFD, Base.FileRedirect, IO}})
    @ Base ./process.jl:236
  [6] _spawn
    @ ./process.jl:148 [inlined]
  [7] run(::Base.CmdRedirect; wait::Bool)
    @ Base ./process.jl:516
  [8] run
    @ ./process.jl:510 [inlined]
  [9] open(s::Solver)
    @ Satisfiability ~/.julia/packages/Satisfiability/3uljf/src/call_solver.jl:134
 [10] talk_to_solver(input::String, s::Solver)
    @ Satisfiability ~/.julia/packages/Satisfiability/3uljf/src/call_solver.jl:162
 [11] sat!(::BoolExpr, ::Vararg{BoolExpr}; solver::Solver, logic::String, clear_values_if_unsat::Bool, line_ending::String, start_commands::String, end_commands::String)                                                                                                                                         
    @ Satisfiability ~/.julia/packages/Satisfiability/3uljf/src/sat.jl:50
 [12] top-level scope
    @ none:7
 [13] eval
    @ ./boot.jl:430 [inlined]
 [14] eval
    @ ./sysimg.jl:48 [inlined]
 [15] macro expansion
    @ ~/.julia/packages/Satisfiability/3uljf/test/README_tests.jl:13 [inlined]
 [16] macro expansion
    @ ~/.julia/juliaup/julia-1.11.1+0.x64.linux.gnu/share/julia/stdlib/v1.11/Test/src/Test.jl:676 [inlined]
 [17] test_julia_examples_in_markdown(path::String)
    @ Main ~/.julia/packages/Satisfiability/3uljf/test/README_tests.jl:12
 [18] macro expansion
    @ ~/.julia/packages/Satisfiability/3uljf/test/README_tests.jl:28 [inlined]
 [19] macro expansion
    @ ~/.julia/juliaup/julia-1.11.1+0.x64.linux.gnu/share/julia/stdlib/v1.11/Test/src/Test.jl:1700 [inlined]
 [20] top-level scope
    @ ~/.julia/packages/Satisfiability/3uljf/test/README_tests.jl:24
 [21] include(fname::String)
    @ Main ./sysimg.jl:38
 [22] top-level scope
    @ ~/.julia/packages/Satisfiability/3uljf/test/runtests.jl:49
 [23] include(fname::String)
    @ Main ./sysimg.jl:38
 [24] top-level scope
    @ none:6
 [25] eval
    @ ./boot.jl:430 [inlined]
 [26] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:296
 [27] _start()
    @ Base ./client.jl:531Test Summary:           | Pass  Fail  Total  Time
Test README.md examples |    9     1     10  7.4s
ERROR: LoadError: Some tests did not pass: 9 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /home/.julia/packages/Satisfiability/3uljf/test/README_tests.jl:23
in expression starting at /home/.julia/packages/Satisfiability/3uljf/test/runtests.jl:49
ERROR: Package Satisfiability errored during testing
```

### After using `TestItemRunner.jl`

```julia
julia> using Satisfiability

(@v1.11) pkg> test Satisfiability

     Testing Satisfiability
      Status `/tmp/jl_C4wYQX/Project.toml`
  [160ab843] Satisfiability v0.2.0 `~/Desktop/SAT/Satisfiability.jl`
  [f8b46487] TestItemRunner v1.0.5
  [1bc4e1ec] z3_jll v4.13.3+0
  [56ddb016] Logging v1.11.0
  [8dfed614] Test v1.11.0
  [4ec0a83e] Unicode v1.11.0
      Status `/tmp/jl_C4wYQX/Manifest.toml`
  [692b3bcd] JLLWrappers v1.6.1
  [21216c6a] Preferences v1.4.3
  [160ab843] Satisfiability v0.2.0 `~/Desktop/SAT/Satisfiability.jl`
  [f8b46487] TestItemRunner v1.0.5
  [1c621080] TestItems v1.0.0
⌃ [3eaa8342] libcxxwrap_julia_jll v0.11.2+1
  [1bc4e1ec] z3_jll v4.13.3+0
  [0dad84c5] ArgTools v1.1.2
  [56f22d72] Artifacts v1.11.0
  [2a0f44e3] Base64 v1.11.0
  [ade2ca70] Dates v1.11.0
  [f43a241f] Downloads v1.6.0
  [7b1f6079] FileWatching v1.11.0
  [b77e0a4c] InteractiveUtils v1.11.0
  [b27032c2] LibCURL v0.6.4
  [76f85450] LibGit2 v1.11.0
  [8f399da3] Libdl v1.11.0
  [56ddb016] Logging v1.11.0
  [d6f4376e] Markdown v1.11.0
  [ca575930] NetworkOptions v1.2.0
  [44cfe95a] Pkg v1.11.0
  [de0858da] Printf v1.11.0
  [9a3f8284] Random v1.11.0
  [ea8e919c] SHA v0.7.0
  [9e88b42a] Serialization v1.11.0
  [fa267f1f] TOML v1.0.3
  [a4e569a6] Tar v1.10.0
  [8dfed614] Test v1.11.0
  [cf7118a7] UUIDs v1.11.0
  [4ec0a83e] Unicode v1.11.0
  [e66e0078] CompilerSupportLibraries_jll v1.1.1+0
  [781609d7] GMP_jll v6.3.0+0
  [deac9b47] LibCURL_jll v8.6.0+0
  [e37daf67] LibGit2_jll v1.7.2+0
  [29816b5a] LibSSH2_jll v1.11.0+1
  [c8ffd9c3] MbedTLS_jll v2.28.6+0
  [14a3606d] MozillaCACerts_jll v2023.12.12
  [83775a58] Zlib_jll v1.2.13+1
  [8e850ede] nghttp2_jll v1.59.0+0
  [3f19e933] p7zip_jll v17.4.0+2
        Info Packages marked with ⌃ have new versions available and may be upgradable.
     Testing Running tests...
skipping gpu tests (set GPU_TESTS=true to test gpu)
Starting tests with 1 threads out of `Sys.CPU_THREADS = 4`...
[ Info: Check that redefining a variable yields a warning. One warning will be emitted.
┌ Warning: Duplicate variable name z of type Bool
└ @ Satisfiability ~/Desktop/SAT/Satisfiability.jl/src/BoolExpr.jl:41
Test Summary: | Pass  Broken  Total     Time
Package       |  316       1    317  1m08.2s
     Testing Satisfiability tests passed 
```

If there is a bug somewhere, now it can be easily detected. For instance:

```julia
Test Summary:                      | Pass  Fail  Broken  Total     Time
Package                            |  325     1       1    327  1m13.9s
  test/int_real_tests.jl           |   44                   44    18.6s
  test/ufunc_tests.jl              |   18                   18     4.5s
  test/extra_tests.jl              |    3                    3     1.1s
  test/output_parse_tests.jl       |   14                   14     1.5s
  test/bitvector_tests.jl          |   87                   87    16.0s
  test/smt_representation_tests.jl |   15             1     16     3.3s
  test/README_tests.jl             |    9     1             10     8.4s
    README.md exampes              |    9     1             10     8.4s
      Test README.md examples      |    9     1             10     8.4s
  test/boolean_operation_tests.jl  |   75                   75    14.0s
  test/solver_interface_tests.jl   |   60                   60     6.4s
ERROR: LoadError: Some tests did not pass: 325 passed, 1 failed, 0 errored, 1 broken.
in expression starting at /Desktop/SAT/Satisfiability.jl/test/runtests.jl:42
ERROR: Package Satisfiability errored during testing
```

Edit: 

Please try running `] test Satisfiability` in REPL, it will now test the entire package! The 1 broken error is due to line `52 `of `smt_representation.jl`. The expression `smt(ite(x,y,z)) `evaluates to the expanded form, so when we test  `@test smt(ite(x,y,z)) ≈ smt(x, assert=false)*smt(y, assert=false)*smt(z, assert=false)*"(assert (ite x y z))\n"`, it says not equal. Even testing with the result says not equal for some weird reason, so please check it on your end. I will check it further as well.
