### PR TITLE
minor documentation fixes

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -4,10 +4,10 @@ Pages = ["advanced.md"]
 Depth = 3
 ```
 
-Note: Some of the options described on this page require you to use the SMTLIB2 specification language directly.
+!!! note Some of the options described on this page require you to use the [SMTLIB2](https://smt-lib.org/papers/smt-lib-reference-v2.6-r2024-09-20.pdf) specification language directly.
 
 ## Custom solver options and using other solvers (Experimental)
-In theory, you can call any SMTLIB2 compliant solver using its **interactive** command-line interface. In practice, this can be tricky and this feature is considered experimental.
+In theory, you can call any [SMTLIB2](https://smt-lib.org/papers/smt-lib-reference-v2.6-r2024-09-20.pdf) compliant solver using its **interactive** command-line interface. In practice, this can be tricky and this feature is considered experimental.
 
 To customize solver options or use a different (unsupported) solver, use the syntax
 
@@ -16,38 +16,38 @@ solver = Solver("My Solver", `program_name --option1 --option2`)
 sat!(problem, solver=solver) # sat! will use your provided command to invoke the solver
 ```
 
-The command you provide must launch a solver that accepts SMTLIB2-formatted commands and can respond to `(get-model)` in SAT mode. (An example of a command that does NOT work is `cvc5 --interactive`, because `CVC5` cannot answer `(get-model)` without the `--produce-models` option.)
+The command you provide must launch a solver that accepts [SMTLIB2](https://smt-lib.org/papers/smt-lib-reference-v2.6-r2024-09-20.pdf)-formatted commands and can respond to `(get-model)` in SAT mode. (An example of a command that does NOT work is `cvc5 --interactive`, because [CVC5](https://github.com/cvc5/cvc5) cannot answer `(get-model)` without the `--produce-models` option.)
 
 
 ### Debugging tips
 
 * To troubleshoot your custom solver, you can use `print(smt(expr))` to print the SMT commands for your problem, call the solver from your own command-line and paste in the contents of your SMT file. Then issue the commands `(check-sat)` and, if satisfiable, `(get-model)`. This is exactly what Satisfiability.jl does when you call  `sat!`.
 * Open your custom solver in interactive mode, try to solve the problem and then check its `command_history`. This is a list of all the commands sent to the solver. You can open an instance of the solver in your command line and paste in the commands to see the output for yourself. Look out for warnings and errors printed by the solver, which often cause output parsing errors.
-* Startup messages and command prompts cause output parsing errors. Example: `cvc4 --lang smt2 --interactive --produce-models --incremental` prints both a startup message and a `CVC4>` command prompt that confuse our parser. Compare this to `cvc4 --interactive --produce-models --incremental --no-interactive-prompt` which doesn't include a command prompt or startup message. (However, CVC4 doesn't work for another reason discussed below.)
+* Startup messages and command prompts cause output parsing errors. Example: `cvc4 --lang smt2 --interactive --produce-models --incremental` prints both a startup message and a `CVC4>` command prompt that confuse our parser. Compare this to `cvc4 --interactive --produce-models --incremental --no-interactive-prompt` which doesn't include a command prompt or startup message. However, [CVC4](https://cvc4.github.io/) doesn't work for another reason discussed below.
 * The solver should produce models or `sat!` won't work. The command `(get-model)` is issued internally when a problem is satisfiable.
 
 
 ### Open an issue!
-We want Satisfiability.jl to be compatible with more solvers and are interested in investigating these issues. Please attach a minimum working example of your code and mention what OS you're on and how you installed the solver.
+We want `Satisfiability.jl` to be compatible with more solvers and are interested in investigating these issues. Please attach a minimum working example of your code and mention what OS you're on and how you installed the solver.
 
 ### Known issue: CVC4 doesn't work!
-We are not aware of a way to make CVC4 work with Satisfiability.jl because CVC4 echoes the input to the output (see [issue #57](https://github.com/elsoroka/Satisfiability.jl/issues/57)). CVC5 doesn't do this and works well. If you have a suggestion to get around this behvaior, please let us know.
+We are not aware of a way to make [CVC4](https://cvc4.github.io/) work with `Satisfiability.jl` because [CVC4](https://cvc4.github.io/) echoes the input to the output (see [issue #57](https://github.com/elsoroka/Satisfiability.jl/issues/57)). [CVC5](https://github.com/cvc5/cvc5) doesn't do this and works well. If you have a suggestion to get around this behavior, please let us know.
 
 ## Setting the solver logic
 You can set the solver logic using an optional keyword argument in `sat!`.
-The solver logic must be a string corresponding to a [valid SMT-LIB logic](http://smtlib.cs.uiowa.edu/logics.shtml). Users are responsible for selecting a logic that reflects the problem they intend to solve - Satisfiability.jl does not perform any correctness checking. Here's an example for Yices, which **requires** the user to set the solver logic (some other solvers, such as Z3 and CVC5, will automatically infer a suitable logic if one isn't explicitly set).
+The solver logic must be a string corresponding to a [valid SMT-LIB logic](http://smtlib.cs.uiowa.edu/logics.shtml). Users are responsible for selecting a logic that reflects the problem they intend to solve - `Satisfiability.jl` does not perform any correctness checking. Here's an example for [Yices](https://yices.csl.sri.com/), which **requires** the user to set the solver logic (some other solvers, such as [Z3](https://github.com/Z3Prover/z3) and [CVC5](https://github.com/cvc5/cvc5), will automatically infer a suitable logic if one isn't explicitly set).
 ```julia
 status = sat!(expr, solver=Yices(), logic="QF_UFLIA")
 ```
 
 ### Custom interactions using `send_command`
-Satisfiability.jl provides an interface to issue SMT-LIB commands and receive SMT-LIB-formatted solver responses programmatically. This is useful if you wish to build your own decision logic or parser using advanced solver functionality.
+`Satisfiability.jl` provides an interface to issue [SMT-LIB](https://smt-lib.org/language.shtml) commands and receive [SMT-LIB](https://smt-lib.org/language.shtml)-formatted solver responses programmatically. This is useful if you wish to build your own decision logic or parser using advanced solver functionality.
 
-If you just want to use an SMT solver interactively, for example by `push`ing or `pop`ping assertions, check out [Interactive Solving](interactive.md).
+If you just want to use an [SMT solver](https://avigad.github.io/lamr/using_smt_solvers.html) interactively, for example by `push`ing or `pop`ping assertions, check out [Interactive Solving](interactive.md).
 
 !!! note SMT-LIB solver modes.
 
-In the SMT-LIB specification, after entering a problem and issuing the command `(check-sat)` the solver will be in either `sat` or `unsat` mode. The solver mode determines which commands are valid: for example, `(get-unsat-core)` is only valid in `unsat` mode and `(get-model)` is only valid in `sat` mode. You can find descriptions of modes and listings of valid commands in the latest [SMT-LIB Standard](http://www.smtlib.org/).
+In the [SMT-LIB](https://smt-lib.org/language.shtml) specification, after entering a problem and issuing the command `(check-sat)` the solver will be in either `sat` or `unsat` mode. The solver mode determines which commands are valid: for example, `(get-unsat-core)` is only valid in `unsat` mode and `(get-model)` is only valid in `sat` mode. You can find descriptions of modes and listings of valid commands in the latest [SMT-LIB Standard](http://www.smtlib.org/).
 
 Here's an example.
 ```jldoctest; output = false
@@ -80,7 +80,7 @@ status = unsat
 ()
 ```
 
-When using this functionality, you are responsible for keeping track of the solver mode and parsing the result of `send_command`. For convenience, `parse_model(model::String)` can parse the result of the SMT-LIB command `(get-model)`, returning a dictionary with variable names as keys and satisfying assignments as values.
+When using this functionality, you are responsible for keeping track of the solver mode and parsing the result of `send_command`. For convenience, `parse_model(model::String)` can parse the result of the [SMT-LIB](https://smt-lib.org/language.shtml) command `(get-model)`, returning a dictionary with variable names as keys and satisfying assignments as values.
 
 
 **Checking if the response is complete**
@@ -93,7 +93,7 @@ The `send_command` function has an optional argument `is_done` for checking whet
 
 !!! warning Multiple parenthesized statements
 
-If your command produces a response with multiple separate statements, for example `(statement_1)\n(statement_2)`, `nested_parens_match` is not guaranteed to return the entire response. The intended use case is `((statement_1)\n(statement_2))`. This should only happen if you issue two SMT-LIB commands at once.
+If your command produces a response with multiple separate statements, for example `(statement_1)\n(statement_2)`, `nested_parens_match` is not guaranteed to return the entire response. The intended use case is `((statement_1)\n(statement_2))`. This should only happen if you issue two [SMT-LIB](https://smt-lib.org/language.shtml) commands at once.
 
 **Customizing `is_done`**
 
@@ -101,6 +101,6 @@ A custom function `is_done(response::String)::Bool`, should have the following b
 * `is_done` returns `true` if the given `response` is valid (in whatever sense you define) and `false` if not.
 * `send_command` will WAIT for more output while `is_done` is false.
 
-SAT solvers can be slow and some commands produce long outputs. Without `is_done`, `send_command` could receive a partial response and prematurely return.
+[SAT solvers](https://avigad.github.io/lamr/using_sat_solvers.html) can be slow and some commands produce long outputs. Without `is_done`, `send_command` could receive a partial response and prematurely return.
 
 For full implementation details, please see the [source code](https://github.com/elsoroka/Satisfiability.jl/blob/main/src/call_solver.jl) of `call_solver.jl`.

--- a/docs/src/example_bv_mini.md
+++ b/docs/src/example_bv_mini.md
@@ -4,7 +4,7 @@ BitVectors represent arrays of binary values. Because they model how data is rep
 
 These two mini-examples are taken from [Microsoft's Z3 documentation](https://microsoft.github.io/z3guide/docs/theories/Bitvectors/).
 
-First, we want to prove the statement "a bitvector x is a power of two or zero if and only if x & (x - 1) is zero", where & represents bitwise and.
+First, we want to prove the statement "a BitVector x is a power of two or zero if and only if x & (x - 1) is zero", where & represents bitwise and.
 
 This is useful because it provides a fast way to check that fixed size numbers are powers of two. We'll check the property for 8 bits.
 

--- a/docs/src/example_job_shop.md
+++ b/docs/src/example_job_shop.md
@@ -1,4 +1,3 @@
-
 # Job shop scheduling
 
 The job shop scheduling problem is a linear integer problem arising in operations research.

--- a/docs/src/example_scheduling.md
+++ b/docs/src/example_scheduling.md
@@ -1,16 +1,15 @@
 # Finding a meeting time
-We have n people's availabilities for the meeting times 9a, 10a, 11a, 12, 1p, 2p, 3p, 4p. Each person's availability is reprsented as a Boolean vector ``a^\top\in \{0,1\}^8``.
+We have the availabilities of `n` people for the meeting times `9a`, `10a`, `11a`, `12`, `1p`, `2p`, `3p`, `4p`. Each person's availability is represented as a Boolean vector ``a^\top\in \{0,1\}^8``.
 We would like to schedule ``J`` meetings between different groups of people, represented by ``J`` index sets ``\mathcal{I_j}\subseteq\{1,\dots,n\}``.
 
-
-Rules:
-* Each meeting ``\mathcal{I}_j`` must occur at one time ``t``.
-* All people attending meeting ``\mathcal{I}_j`` must be available at time ``t``.
-* All people attending meeting ``\mathcal{I}_j`` must not be attending another meeting at time ``t``.
-* No attendee should have >2 hours of consecutive meetings.
+# Rules
+* Each meeting ``\mathcal{I}_j`` must be scheduled at exactly one time ``t``.
+* All attendees of meeting ``\mathcal{I}_j`` must be available at the scheduled time ``t``.
+* No attendee of ``\mathcal{I}_j`` can participate in another meeting scheduled at the same time ``t``.
+* No attendee should have more than two consecutive hours of meetings.
 
 ### Setup
-We concatenate the availability row vectors into a 5 x 8 Boolean matrix ``\bar A``.
+We concatenate the availability row vectors into a `5 × 8` Boolean matrix ``\bar A``.
 ```jldoctest label5; output = false
 using Satisfiability
 
@@ -88,7 +87,7 @@ and_e22650cf96be44e6
  |  | A_4_8
 ```
 
-For each meeting ``j``, all attendees in index set ``\mathcal{I_j}`` must be available at some time ``t`` and not attending another meeting.
+For each meeting ``j``, all attendees in the index set ``\mathcal{I_j}`` must be available at some time ``t`` and not attend another meeting.
 ```jldoctest label5; output = false
 M = [and(A[index_sets[j], t]) for j=1:J, t=1:T]
 

--- a/docs/src/example_scheduling.md
+++ b/docs/src/example_scheduling.md
@@ -87,7 +87,7 @@ and_e22650cf96be44e6
  |  | A_4_8
 ```
 
-For each meeting ``j``, all attendees in the index set ``\mathcal{I_j}`` must be available at some time ``t`` and not attend another meeting.
+For each meeting ``j``, all attendees in the index set ``\mathcal{I_j}`` must be available at some time ``t`` and not be attending another meeting at time ``t``.
 ```jldoctest label5; output = false
 M = [and(A[index_sets[j], t]) for j=1:J, t=1:T]
 

--- a/docs/src/example_uninterpreted_func.md
+++ b/docs/src/example_uninterpreted_func.md
@@ -1,6 +1,5 @@
 # Uninterpreted Functions
 
-
 An uninterpreted function is a function where the mapping between input and output is not known. The task of the SMT solver is then to determine a mapping such that some SMT expression holds true.
 
 Satisfiability.jl represents uninterpreted functions as callable structs. This enables the simple syntax:

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -8,14 +8,14 @@ Depth = 3
 Please open a Github issue! This is a new package and we would love to hear your suggestions, bug reports, feature requests, and other commentary.
 
 ## Isn't this functionality included in JuMP?
-[JuMP](https://jump.dev/) provides support for [integer and Boolean-valued variables](https://jump.dev/JuMP.jl/stable/manual/variables/#Binary-variables), however it is developed primarily to support mathematical optimization over real-valued or integer-valued variables and continuous functions. As such, JuMP interfaces with solvers such as ECOS, MOSEK, and Gurobi that are intended for continuous optimization problems. When you use JuMP to solve a problem with discrete variables, your solver will likely use a branch-and-bound style method.
+[JuMP](https://jump.dev/) provides support for [integer and Boolean-valued variables](https://jump.dev/JuMP.jl/stable/manual/variables/#Binary-variables), however it is developed primarily to support mathematical optimization over real-valued or integer-valued variables and continuous functions. As such, JuMP interfaces with solvers such as [ECOS](https://github.com/embotech/ecos), [MOSEK](https://www.mosek.com/), and [Gurobi](https://www.gurobi.com/) that are intended for [continuous optimization problems](https://en.wikipedia.org/wiki/Continuous_optimization). When you use JuMP to solve a problem with discrete variables, your solver will likely use a [branch-and-bound](https://en.wikipedia.org/wiki/Branch_and_bound) style method.
 
 ### Should I use JuMP or Satisfiability.jl?
-If you have a problem with mostly real variables and a few discrete integer or Boolean variables, you should probably use JuMP to call a branch-and-bound solver.
+If you have a problem with mostly real variables and a few discrete integer or Boolean variables, you should probably use JuMP to call a [branch-and-bound](https://en.wikipedia.org/wiki/Branch_and_bound) solver.
 
-If you have a problem with only discrete variables, especially a large one, you should consider using an SMT solver. SMT can also represent specific variable types, like BitVectors, that JuMP cannot.
+If you have a problem with only discrete variables, especially a large one, you should consider using an [SMT solver](https://smt-lib.org/solvers.shtml). SMT can also represent specific variable types, like BitVectors, that JuMP cannot.
 
-## How do I solve SMT problems in other langugages?
+## How do I solve SMT problems in other languages?
 * In Python, you can use [PySMT](https://github.com/pysmt/pysmt) to access a wide variety of solvers.
 
 * Similarly, Java has [JavaSMT](https://github.com/sosy-lab/java-smt).
@@ -28,27 +28,26 @@ If you have a problem with only discrete variables, especially a large one, you 
 
 ### Are there other SMT libraries in Julia?
 * There are [Julia bindings](https://github.com/ahumenberger/Z3.jl) for the Z3 C++ API.
-* PicoSAT also has [Julia bindings](https://github.com/sisl/PicoSAT.jl). You'll need to understand CNF format to use these.
+* PicoSAT also has [Julia bindings](https://github.com/sisl/PicoSAT.jl). You'll need to understand the [CNF format](https://en.wikipedia.org/wiki/Conjunctive_normal_form) to use these.
 * Here is a [package](https://github.com/dpsanders/SatisfiabilityInterface.jl) for modelling discrete constraint satisfaction problems and encoding them to Boolean satisfiability (SAT) problems. 
 
-To our knowledge, Satisfiability.jl is the first general-purpose SMT library in Julia.
+To our knowledge, `Satisfiability.jl` is the first general-purpose SMT library in Julia.
 
 ## What about other theories in the SMT standard?
-In the future support may be added for additional theories supported in the SMTLIB2 standard, such as bitvectors and arrays.
+In the future support may be added for additional theories supported in the [SMTLIB2 standard](https://stp.readthedocs.io/en/latest/smt-input-language.html), such as bitvectors and arrays.
 
 ## How can I retrieve a proof or unsat core from the solver?
-Unsatisfiability proofs are difficult to support because the SMT2 standard doesn't specify their format - it's solver-dependent. Although we don't provide an explicit function, you can still retrieve a proof in two ways:
+Unsatisfiability proofs are difficult to support because the [SMTLIB2 standard](https://stp.readthedocs.io/en/latest/smt-input-language.html) doesn't specify their format - it's solver-dependent. Although we don't provide an explicit function, you can still retrieve a proof in two ways:
 
 * Instead of calling `sat!`, use `save` to write the SMT representation of your problem to a file. Then invoke the solver from your command line, feed it the file and issue `(get-proof)` in `unsat` mode.
 * Call `sat!` on your problem as shown [here](advanced.md#custom-interactions-with-solvers), then use `send_command` to issue `(get-proof)`.
 
 
 ## What does Satisfiability.jl actually do?
-We provide a high-level interface to SMT solvers. SMT solvers can accept input in the [SMT2](http://www.smtlib.org/) format, which is very powerful but not easy to read. When you specify an SMT problem in Satisfiability.jl and call `sat!`, we generate an SMT2-formatted **representation** of the problem, feed it to a solver, then interpret the result.
+We provide a high-level interface to SMT solvers. SMT solvers can accept input in the [SMT2](http://www.smtlib.org/) format, which is very powerful but not easy to read. When you specify an SMT problem in `Satisfiability.jl` and call `sat!`, we generate an SMTLIB2-formatted **representation** of the problem, feed it to a solver, then interpret the result.
 
 # LFAQ
 (Less frequently-asked questions.)
 
 ## Why is `sat!` so slow for real-valued variables?
 Because the SMT theory of real-valued variables is incomplete.
-

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -9,7 +9,7 @@ Use the `@satvariable` macro to define a variable.
 ```@docs
 @satvariable
 ```
-Satisfiability.jl currently supports propositional logic, integer and real-valued arithmetic, and bitvectors. Support for additional SMT-LIB theories is planned in future versions.
+`Satisfiability.jl` currently supports [propositional logic](https://avigad.github.io/lamr/propositional_logic.html), [integer](https://smt-lib.org/theories-Ints.shtml) and [real-valued arithmetic](https://smt-lib.org/theories-Reals.shtml), and [BitVectors](https://smt-lib.org/theories-FixedSizeBitVectors.shtml). Support for additional [SMT-LIB theories](https://smt-lib.org/theories.shtml) is planned in future versions.
 ```@docs
 BoolExpr(name::String)
 IntExpr(name::String)
@@ -17,7 +17,7 @@ RealExpr(name::String)
 BitVectorExpr(name::String, length::Int)
 ```
 
-An **uninterpreted function** is a function where the mapping between input and output is not known. The task of the SMT solver is then to determine a mapping such that some SMT expression holds true.
+An **uninterpreted function** is a function where the mapping between input and output is not known. The task of the [SMT solver](https://avigad.github.io/lamr/using_smt_solvers.html) is then to determine a mapping such that some SMT expression holds true.
 ```@docs
 @uninterpreted
 ```
@@ -38,7 +38,7 @@ distinct(z1::BoolExpr, z2::BoolExpr)
 ```
 
 ## Arithmetic operations
-These are operations in the theory of integer and real-valued arithmetic.
+These are operations in the theory of [integer](https://smt-lib.org/theories-Ints.shtml) and [real-valued arithmetic](https://smt-lib.org/theories-Reals.shtml).
 
 Note that `+`, `-`, and `*` follow type promotion rules: if both `a` and `b` are `IntExpr`s, `a+b` will have type `IntExpr`. If either `a` or `b` is a `RealExpr`, the result will have type `RealExpr`. Integer division `div(a,b)` is defined only for `IntExpr`s. Real-valued division `a\b` is defined only in the theory of real-valued arithmetic.
 For a formal definition of the theory of integer arithmetic, see Figure 3.3 in *The SMT-LIB Standard, Version 2.6*.
@@ -81,7 +81,7 @@ to_real(a::IntExpr)
 
     a + concat(bvconst(0x0, 4), b)
 ```
-The SMT-LIB standard BitVector is often used to represent operations on fixed-size integers. Thus, BitVectorExprs can interoperate with Julia's native Integer, Unsigned and BigInt types.
+The [SMT-LIB](https://smt-lib.org/language.shtml) standard BitVector is often used to represent operations on fixed-size integers. Thus, BitVectorExprs can interoperate with Julia's native Integer, Unsigned and BigInt types.
 
 ### Bitwise operators
 In addition to supporting the comparison operators above and arithmetic operators `+`, `-`, and `*`, the following BitVector-specific operators are available.
@@ -115,7 +115,7 @@ sgt(a::BitVectorExpr{UInt8}, b::BitVectorExpr{UInt8})
 sge(a::BitVectorExpr{UInt8}, b::BitVectorExpr{UInt8})
 ```
 
-The following word-level operations are also available in the SMT-LIB standard, either as core operations or defined in the [SMT-LIB BitVector logic](https://smtlib.cs.uiowa.edu/logics-all.shtml#QF_BV).
+The following word-level operations are also available in the [SMT-LIB](https://smt-lib.org/language.shtml) standard, either as core operations or defined in the [SMT-LIB BitVector logic](https://smtlib.cs.uiowa.edu/logics-all.shtml#QF_BV).
 ```@docs
 concat(a::Array{T}) where T
 repeat(a::BitVectorExpr{UInt8}, n::Int64)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,5 @@
 # Solving SMT Problems in Julia
-Satisfiability.jl is a package for representing Boolean satisfiability (SAT) and selected other satisfiability modulo theories (SMT) problems in Julia. This package provides a simple front-end interface to common SMT solvers, including full support for vector-valued and matrix-valued expressions.
+Satisfiability.jl is a package for representing [Boolean satisfiability (SAT)](https://en.wikipedia.org/wiki/Boolean_satisfiability_problem) and selected other [satisfiability modulo theories (SMT)](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories) problems in Julia. This package provides a simple front-end interface to common [SMT solvers](https://smt-lib.org/solvers.shtml), including full support for vector-valued and matrix-valued expressions.
 
 ```@contents
 Pages = ["index.md"]
@@ -34,15 +34,15 @@ Given a Boolean expression, the associated SAT problem can be posed as:
 ### SMT problems
 Satisfiability modulo theories is a superset of Boolean satisfiability. SMT encompasses many other theories besides Boolean logic, several of which are supported here.
 
-In the **theory of integers**, we can define integer-valued variables and operations such as `+`, `-`, `*` and the comparisons `<`, `<=`, `==`, `=>`, `>`. For example, we could determine whether there exists a satisfying assignment for integers `a` and `b` such that `a <= b, b <= 1 and a + b >= 2`. (There is - set `a = 1` and ` b = 1`.)
+In the [theory of integers](https://smt-lib.org/theories-Ints.shtml), we can define integer-valued variables and operations such as `+`, `-`, `*` and the comparisons `<`, `<=`, `==`, `=>`, `>`. For example, we could determine whether there exists a satisfying assignment for integers `a` and `b` such that `a <= b, b <= 1 and a + b >= 2`. (There is - set `a = 1` and ` b = 1`.)
 
-In the **theory of reals**, we can define real-valued variables and operations. Reals use the same operations as integers, plus division (`\`). However, algorithms to solve SMT problems over real variables are often slow and not guaranteed to find a solution. If you have a problem over only real-valued variables, you should use [JuMP](https://jump.dev/) and a solver like Gurobi instead.
+In the [theory of reals](https://smt-lib.org/theories-Reals.shtml), we can define real-valued variables and operations. Reals use the same operations as integers, plus division (`\`). However, algorithms to solve SMT problems over real variables are often slow and not guaranteed to find a solution. If you have a problem over only real-valued variables, you should use [JuMP](https://jump.dev/) and a solver like Gurobi instead.
 
-In the **theory of fixed-length BitVectors** one can prove properties over BitVectors, which are useful for representing fixed-size integer arithmetic. For example, you can use formal verification to prove correctness of your code - or discover bugs (some examples [here](https://sat-smt.codes code/SAT_SMT_by_example.pdf)), like [the sneaky Binary Search bug that went undetected for 20 years](https://thebittheories.com/the-curious-case-of-binary-search-the-famous-bug-that-remained-undetected-for-20-years-973e89fc212?gi=5adc69f5db4d).
+In the [theory of fixed-length BitVectors](https://smt-lib.org/theories-FixedSizeBitVectors.shtml) one can prove properties over BitVectors, which are useful for representing fixed-size integer arithmetic. For example, you can use formal verification to prove correctness of your code - or discover bugs (some examples [here](https://sat-smt.codes code/SAT_SMT_by_example.pdf)), like [the sneaky Binary Search bug that went undetected for 20 years](https://thebittheories.com/the-curious-case-of-binary-search-the-famous-bug-that-remained-undetected-for-20-years-973e89fc212?gi=5adc69f5db4d).
 
-SMT extends to other theories including IEEE floating-point numbers, arrays and strings. While this package is still under development, we plan to implement support for the [SMT-LIB standard theories](http://smtlib.cs.uiowa.edu/theories.shtml) and operations.
+SMT extends to other theories including [IEEE floating-point numbers](https://smt-lib.org/theories-FloatingPoint.shtml), [arrays](https://smt-lib.org/theories-ArraysEx.shtml) and [strings](https://smt-lib.org/theories-UnicodeStrings.shtml). While this package is still under development, we plan to implement support for the [SMT-LIB standard theories](http://smtlib.cs.uiowa.edu/theories.shtml) and operations.
 
 ## How does Satisfiability.jl work?
 Satisfiability.jl provides an **interface** to SAT solvers that accept input in the [SMTLIB2](http://www.smtlib.org/) format. It works by generating the SMT representation of your problem, then invoking a solver to read said file.
 
-Using this package, you should be able to interact with any solver that implements the SMT-LIB standard. We currently test with [Z3](https://microsoft.github.io/z3guide/) and [CVC5](https://cvc5.github.io/).
+Using this package, you should be able to interact with any solver that implements the [SMT-LIB standard](https://smt-lib.org/standard.shtml). We currently test with [Z3](https://microsoft.github.io/z3guide/) and [CVC5](https://cvc5.github.io/).

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -4,16 +4,16 @@ Pages = ["installation.md"]
 Depth = 3
 ```
 
-**NOTE: To successfully use this package you need a back-end solver installed.** [Z3](https://www.microsoft.com/en-us/research/publication/z3-an-efficient-smt-solver/) will automatically be installed using `z3_jll`.
+!!! note **To successfully use this package you need a back-end solver installed.** [Z3](https://www.microsoft.com/en-us/research/publication/z3-an-efficient-smt-solver/) will automatically be installed using `z3_jll`.
 
-You can also use [cvc5](https://cvc5.github.io/) (although you will have to install it yourself). To use other solvers that implement the SMT-LIB standard, [check this page](advanced.md#Custom-solver-options-and-using-other-solvers) for guidelines.
+You can also use [cvc5](https://cvc5.github.io/) (although you will have to install it yourself). To use other solvers that implement the [SMT-LIB Standard](http://www.smtlib.org/) standard, [check this page](advanced.md#Custom-solver-options-and-using-other-solvers) for guidelines.
 
 ## Installing Satisfiability
 The usual way! `using Pkg; Pkg.add("Satisfiability")`
-Satisfiability will automatically install Z3 on your system if it isn't already installed.
+`Satisfiability.jl` will automatically install [Z3](https://www.microsoft.com/en-us/research/publication/z3-an-efficient-smt-solver/) on your system if it isn't already installed.
 
 ## Installing other Solvers
-Satisfiability uses Julia's Base.Process library to interact with solvers. To successfully install a solver for this package, all you need to do is make sure the appropriate command works in your machine's terminal.
+`Satisfiability.jl` uses [Julia's Base.Process](https://github.com/JuliaLang/julia/blob/master/base/process.jl) library to interact with solvers. To successfully install a solver for this package, all you need to do is make sure the appropriate command works in your machine's terminal.
 
 ### Debian Linux
 
@@ -68,9 +68,9 @@ The workflow for installing any solver is the same!
 * Download the solver
 * Make sure you can invoke it from the command line. On Windows this might include adding its location to your system PATH variable.
 
-The command you use is the command Satisfiability.jl will use. You can specify exactly the command you want by writing `solver = Solver("My Solver", `program_name --option1 --option2`)` - [see here](advanced.md) for more details.
+The command you use is the command `Satisfiability.jl` will use. You can specify exactly the command you want by writing `solver = Solver("My Solver", `program_name --option1 --option2`)` - [see here](advanced.md) for more details.
 
-Be aware of the limitations of your back-end solver - check the manual to ensure it supports the theories you plan to use, and make sure you set the right command line flags. If you're having difficulty using another solver, a good troubleshooting step is to `save` your problem to SMT format in Satisfiability.jl, then feed it to the solver on your command line.
+Be aware of the limitations of your back-end solver - check the manual to ensure it supports the theories you plan to use, and make sure you set the right command line flags. If you're having difficulty using another solver, a good troubleshooting step is to `save` your problem to SMT format in `Satisfiability.jl`, then feed it to the solver on your command line.
 
-**Satisfiability.jl does not warn you if your problem contains a theory or operation that your back-end solver does not support!** For example, if you set the wrong theory in Yices, `sat!` will hang.
-Future versions of Satisfiability.jl may implement warnings about logic/problem mismatches, however difficulties can arise in maintaining the correctness of these warnings as solvers are updated and improved.
+!!!! note **`Satisfiability.jl` does not warn you if your problem contains a theory or operation that your back-end solver does not support!** For example, if you set the wrong theory in [Yices](https://yices.csl.sri.com/)), `sat!` will hang.
+Future versions of `Satisfiability.jl` may implement warnings about logic/problem mismatches, however difficulties can arise in maintaining the correctness of these warnings as solvers are updated and improved.

--- a/docs/src/interactive.md
+++ b/docs/src/interactive.md
@@ -6,7 +6,7 @@ Depth = 3
 
 The simplest way to solve an SMT problem is to call `sat!`. Under the hood, `sat!` translates your problem to the SMT-LIB format, spawns a solver in a new process, feeds in your problem and, if it's satisfiable, requests the satisfying assignment.
 
-However, many use cases require ongoing interaction with the SMT solver. Satisfiability.jl provides this functionality using the `InteractiveSolver` struct, allowing users to interface with a running solver process. A typical interactive workflow looks like this.
+However, many use cases require ongoing interaction with the SMT solver. `Satisfiability.jl` provides this functionality using the `InteractiveSolver` struct, allowing users to interface with a running solver process. A typical interactive workflow looks like this.
 
 **Construct some expressions**
 ```jldoctest label10; output = false
@@ -67,4 +67,4 @@ If you need more granular control over solver commands and responses, check our 
 
 !!! warning Don't set print-success
 
-If you set the SMT-LIB option `(set-option :print-success true)` it will confuse the output parser. Future versions of Satisfiability.jl will address this issue.
+If you set the SMT-LIB option `(set-option :print-success true)` it will confuse the output parser. Future versions of `Satisfiability.jl` will address this issue.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,7 +1,7 @@
 # Tutorial
 Here we present several mini-examples of SMT problems.
 ## Proving the validity of De Morgan's law
-This example is borrowed from Microsoft's [introduction](https://microsoft.github.io/z3guide/docs/logic/propositional-logic/) to Z3 for propositional logic.
+This example is borrowed from Microsoft's [introduction](https://microsoft.github.io/z3guide/docs/logic/propositional-logic/) to `Z3` for propositional logic.
 
 We say a formula is **valid** if it is true for every assignment of values to its variables. For example, `z ∨ ¬z` is valid. (This is useful because a valid formula can provide a useful transformation or simplification of a logical expression.)
 
@@ -76,7 +76,7 @@ Check: 1505
 
 ## Proving properties of fixed-size integer arithmetic
 This example is from Microsoft's [Z3 tutorial](https://microsoft.github.io/z3guide/docs/theories/Bitvectors/).
-A bitvector `x` is a power of two (or zero) if and only if `x & (x - 1)` is zero, where & is bitwise and. We prove this property for an 8-bit vector.
+A Bitvector `x` is a power of two (or zero) if and only if `x & (x - 1)` is zero, where & is bitwise and. We prove this property for an 8-bit vector.
 
 ```jldoctest; output = false
 using Satisfiability


### PR DESCRIPTION
Some minor documentation fixes. I found these resources helpful:

- This seems like a helpful resource! https://avigad.github.io/lamr/using_smt_solvers.html
-  There is some documentation about [process_running](https://docs.julialang.org/en/v1/base/base/#Base.process_running) ,[process_exited](https://docs.julialang.org/en/v1/base/base/#Base.process_exited), but much documentation about Base.Process itself so added the link to Base.Process. https://github.com/JuliaLang/julia/blob/master/base/process.jl.
- When mentioning theories of Int, Real and BitVectors, provided links to each of these theories from https://smt-lib.org/theories.shtml 
- Other minor documentation and typos fixes.

Edit: T̶O̶D̶O̶:̶ ̶I̶t̶ ̶m̶i̶g̶h̶t̶ ̶b̶e̶ ̶h̶e̶l̶p̶f̶u̶l̶ ̶t̶o̶ ̶a̶d̶d̶ ̶a̶ ̶r̶e̶f̶e̶r̶e̶n̶c̶e̶s̶.̶b̶i̶b̶ ̶a̶n̶d̶ ̶r̶e̶f̶e̶r̶e̶n̶c̶e̶s̶.̶m̶d̶ ̶a̶n̶d̶ ̶r̶e̶n̶d̶e̶r̶ ̶t̶h̶e̶ ̶r̶e̶f̶e̶r̶e̶n̶c̶e̶s̶ ̶p̶a̶g̶e̶ ̶v̶i̶a̶ ̶a̶d̶d̶i̶n̶g̶ ̶c̶o̶m̶m̶a̶n̶d̶ ̶i̶n̶ ̶d̶o̶c̶s̶/̶m̶a̶k̶i̶e̶.̶j̶l̶ ̶a̶s̶ ̶w̶e̶l̶l̶ . I forgot about `bibliography.bib`.
