### PR TITLE
tutorial: solving magic square puzzle as a satisfiability problem

### DIFF
--- a/docs/src/example_magic_square.md
+++ b/docs/src/example_magic_square.md
@@ -1,0 +1,95 @@
+# Magic Square
+
+A **[Magic Square](https://en.wikipedia.org/wiki/Magic_square)** is a grid of distinct numbers
+arranged such that the sums of the numbers in each row, each column, and the two diagonals are
+equal. The sum is referred to as the **magic constant**.
+
+### Setup
+
+Given an integer `n`, the task is to fill an `n x n` grid with integers from `1` to `n²` such that:
+- The sum of each row, column, and both diagonals equals the magic constant.
+- All numbers are distinct.
+
+The **magic constant** for an `n x n` magic square is calculated as: ``M = \frac{n \times (n^2 + 1)}``.
+This problem can be formulated as a **satisfiability problem**  where we need to find the values of
+the grid cells that satisfy certain constraints.
+
+### Steps
+
+1. **Variables**: We define variables for each cell in the `n x n` grid. These are integer variables
+representing the values that will be filled in each cell.
+2. **Constraints**:
+   - Each cell must contain an integer between `1` and `n²`.
+   - All numbers in the grid must be distinct.
+   - The sum of each row, column, and the two diagonals must equal the magic constant.
+
+3. **Solver**: We use a SAT solver to find an assignment of values to the grid that satisfies all
+the constraints.
+
+### Solution
+
+```jldoctest label3; output = false
+using Satisfiability
+function magic_square(n)
+    # The magic constant for the square
+    magic = n * (n^2 + 1) ÷ 2
+
+    open(Z3()) do solver
+        # The magic square as a grid of integer variables
+        @satvariable(matrix[1:n, 1:n], Int)
+
+        # Each cell must be in the range 1 to n²
+        for r in 1:n, c in 1:n
+            assert!(solver, and(1 ≤ matrix[r, c], matrix[r, c] ≤ n^2))
+        end
+
+        # All values in the matrix must be distinct
+        mat = [matrix[r, c] for r in 1:n, c in 1:n]
+        assert!(solver, distinct(mat))
+
+        # Sum of rows and columns must equal the magic constant
+        for i in 1:n
+            assert!(solver, sum(matrix[i, :]) == magic) # Row sums
+            assert!(solver, sum(matrix[:, i]) == magic) # Column sums
+        end
+
+        # Diagonal sums must equal the magic constant
+        diag1 = [matrix[i, i] for i in 1:n]
+        diag2 = [matrix[i, n - i + 1] for i in 1:n]
+        assert!(solver, sum(diag1) == magic)
+        assert!(solver, sum(diag2) == magic)
+
+        status, solution = sat!(solver)
+        println(status)
+        matrix = zeros(Int, n, n)
+        for (key, value) in solution
+            parts = split(key, "_")
+            row, col = parse(Int, parts[2]), parse(Int, parts[3])
+            matrix[row, col] = value
+        end
+        for row in 1:n
+            println(join(matrix[row, :], " | "))
+        end
+    end
+end
+
+magic_square(3)
+
+# output
+
+SAT
+8 | 1 | 6
+3 | 5 | 7
+4 | 9 | 2
+
+
+magic_square(4)
+
+# output
+
+SAT
+7 | 1 | 16 | 10
+6 | 14 | 11 | 3
+12 | 4 | 5 | 13
+9 | 15 | 2 | 8
+```

--- a/examples/magic_square.jl
+++ b/examples/magic_square.jl
@@ -1,0 +1,49 @@
+push!(LOAD_PATH, "../src")
+using Satisfiability
+
+function magic_square(n)
+    # The magic constant for the square
+    magic = n * (n^2 + 1) ÷ 2
+
+    open(Z3()) do solver
+        # The magic square as a grid of integer variables
+        @satvariable(matrix[1:n, 1:n], Int)
+
+        # Each cell must be in the range 1 to n²
+        for r in 1:n, c in 1:n
+            assert!(solver, and(1 ≤ matrix[r, c], matrix[r, c] ≤ n^2))
+        end
+
+        # All values in the matrix must be distinct
+        mat = [matrix[r, c] for r in 1:n, c in 1:n]
+        assert!(solver, distinct(mat))
+
+        # Sum of rows and columns must equal the magic constant
+        for i in 1:n
+            assert!(solver, sum(matrix[i, :]) == magic) # Row sums
+            assert!(solver, sum(matrix[:, i]) == magic) # Column sums
+        end
+
+        # Diagonal sums must equal the magic constant
+        diag1 = [matrix[i, i] for i in 1:n]
+        diag2 = [matrix[i, n - i + 1] for i in 1:n]
+        assert!(solver, sum(diag1) == magic)
+        assert!(solver, sum(diag2) == magic)
+
+        status, solution = sat!(solver)
+        println(status)
+        matrix = zeros(Int, n, n)
+        for (key, value) in solution
+            parts = split(key, "_")
+            row, col = parse(Int, parts[2]), parse(Int, parts[3])
+            matrix[row, col] = value
+        end
+        for row in 1:n
+            println(join(matrix[row, :], " | "))
+        end
+    end
+end
+
+
+magic_square(3)
+magic_square(4)


### PR DESCRIPTION
This PR adds the tutorial for solving the [magic square puzzle](https://en.wikipedia.org/wiki/Magic_square) as a satisfiability problem. For smaller values of `n` in `n x n` matrix, it's gives answer immediately but some takes time for large values because each cell is distinct, maybe that's why it takes long time for `n =5`onwards.

Examples:

The sum of rows = 15, sum of cols = 15, sum of diagonal 1 = 15, and diagonal 2 = 15

```
julia> magic_square(3)
SAT
8 | 1 | 6
3 | 5 | 7
4 | 9 | 2
```

The sum of rows = 34, sum of cols = 34, sum of diagonal 1 = 34, and diagonal 2 = 34
```
julia> magic_square(4)
SAT
7 | 1 | 16 | 10
6 | 14 | 11 | 3
12 | 4 | 5 | 13
9 | 15 | 2 | 8
```

The sum of rows = 65, sum of cols = 65, sum of diagonal 1 = 65, and diagonal 2 = 65. It took some time to print this.

```
julia> magic_square(5)
SAT
8 | 22 | 1 | 20 | 14
7 | 9 | 21 | 4 | 24
25 | 18 | 15 | 2 | 5
6 | 13 | 11 | 23 | 12
19 | 3 | 17 | 16 | 10
```

Please let me know whether we can optimize the `magic_square` function to get results faster for `n=5` or `n=6`? Currently, using Python's Z3, it takes about a minute +  (I have not timed it though) for `n=5` or  `n=6` . Thank  you!