### PR TITLE
fix(docs): Add proper dependencies to docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Satisfiability = "160ab843-0bc6-4ba4-9585-b7478b70f443"


### PR DESCRIPTION
This allows to run
```sh
julia --project=docs --color=yes docs/make.jl
```
from the root of the git directory. It previously threw an error caused by missing dependencies.