### PR TITLE
fix(docs): Correct admonition markdown format

### DIFF
--- a/docs/src/interactive.md
+++ b/docs/src/interactive.md
@@ -65,6 +65,7 @@ This is useful when incrementally adding constraints to a problem. [Finding Bad 
 ### How can I get more control over the solver?
 If you need more granular control over solver commands and responses, check our guide on [advanced usage](advanced.md). For suggestions, feel free to open a GitHub issue! This is a new package and we'd like to hear user feedback. 
 
-!!! warning Don't set print-success
+!!! warning 
+    Don't set print-success
 
 If you set the SMT-LIB option `(set-option :print-success true)` it will confuse the output parser. Future versions of `Satisfiability.jl` will address this issue.


### PR DESCRIPTION
This:
![image](https://github.com/user-attachments/assets/cf62ba2c-f1ed-4e13-8a7b-a3a66ac49101)
Instead of current docs:
![image](https://github.com/user-attachments/assets/64436ff1-e71d-4b76-b18f-c3239d1b2173)
