### PR TITLE
Get rid of the red CI badge caused by the red Docs badge fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,7 @@ jobs:
 
       - name: Set up Julia latest version
         uses: julia-actions/setup-julia@latest
-<<<<<<< HEAD
-      - uses: julia-actions/cache@v2
-=======
       - uses: julia-actions/cache@v3
->>>>>>> ed80e6e83b9f493fb70a22232ba8450eff433d80
 
       - name: Run tests
         uses: julia-actions/julia-buildpkg@latest


### PR DESCRIPTION
accidentally committed a merge conflict in .github/workflows/ci.yml